### PR TITLE
Fix migration file extension when publishing from Package

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -4,6 +4,7 @@
 namespace Spatie\LaravelPackageTools;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use ReflectionClass;
 use Spatie\LaravelPackageTools\Exceptions\InvalidPackage;
 
@@ -54,7 +55,7 @@ abstract class PackageServiceProvider extends ServiceProvider
             foreach ($this->package->migrationFileNames as $migrationFileName) {
                 if (! $this->migrationFileExists($migrationFileName)) {
                     $this->publishes([
-                        $this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => database_path('migrations/' . now()->format('Y_m_d_His') . '_' . $migrationFileName),
+                        $this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => database_path('migrations/' . now()->format('Y_m_d_His') . '_' . Str::finish($migrationFileName, '.php')),
                     ], "{$this->package->name}-migrations");
                 }
             }

--- a/tests/PackageServiceProviderTests/PackageMigrationTest.php
+++ b/tests/PackageServiceProviderTests/PackageMigrationTest.php
@@ -23,6 +23,6 @@ class PackageMigrationTest extends PackageServiceProviderTestCase
             ->artisan('vendor:publish --tag=laravel-package-tools-migrations')
             ->assertExitCode(0);
 
-        $this->assertFileExists(database_path('migrations/2020_01_01_000000_create_laravel_package_tools_table'));
+        $this->assertFileExists(database_path('migrations/2020_01_01_000000_create_laravel_package_tools_table.php'));
     }
 }


### PR DESCRIPTION
When Package has registered migrations to publish,
resulting migration file being published without '.php'
file extension. In order to get Migration discovered and
available to run, file should be properly named in the form
of 'Y_m_d_His_migration_file_name_here.php' and should have
'.php' extension.