### PR TITLE
Fix migrationFileExists function

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -98,10 +98,10 @@ abstract class PackageServiceProvider extends ServiceProvider
 
     public static function migrationFileExists(string $migrationFileName): bool
     {
-        $len = strlen($migrationFileName);
+        $len = strlen($migrationFileName) + 4;
 
         foreach (glob(database_path("migrations/*.php")) as $filename) {
-            if ((substr($filename, -$len) === $migrationFileName)) {
+            if ((substr($filename, -$len) === $migrationFileName . '.php')) {
                 return true;
             }
         }


### PR DESCRIPTION
Because you have on line 59 variable $migrationFileName without .php and you set it:                       
```
$this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => database_path('migrations/' . now()->format('Y_m_d_His') . '_' . Str::finish($migrationFileName, '.php')),
```
so you must check existing migrations (function migrationFileExists) with .php extension too. 
If you don't do that, condition can not work properly, e.g. current functionality return false _te_users_table.php === create_users_table_.
This pull request fix this condition and it will return true __create_users_table.php === create_users_table.php_.