### PR TITLE
Allows parameters for setup methods to be passed in as a spread array

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -38,6 +38,11 @@ class Package
         return $this;
     }
 
+    public function shortName(): string
+    {
+        return Str::after($this->name, 'laravel-');
+    }
+
     public function hasViews(): self
     {
         $this->hasViews = true;
@@ -66,9 +71,12 @@ class Package
         return $this;
     }
 
-    public function hasMigrations(array $migrationFileNames): self
+    public function hasMigrations(...$migrationFileNames): self
     {
-        $this->migrationFileNames = array_merge($this->migrationFileNames, $migrationFileNames);
+        $this->migrationFileNames = array_merge(
+            $this->migrationFileNames,
+            collect($migrationFileNames)->flatten()->toArray()
+        );
 
         return $this;
     }
@@ -80,9 +88,9 @@ class Package
         return $this;
     }
 
-    public function hasCommands(array $commandClassNames): self
+    public function hasCommands(...$commandClassNames): self
     {
-        $this->commands = array_merge($this->commands, $commandClassNames);
+        $this->commands = array_merge($this->commands, collect($commandClassNames)->flatten()->toArray());
 
         return $this;
     }
@@ -94,9 +102,9 @@ class Package
         return $this;
     }
 
-    public function hasRoutes(array $routeFileNames): self
+    public function hasRoutes(...$routeFileNames): self
     {
-        $this->routeFileNames = array_merge($this->routeFileNames, $routeFileNames);
+        $this->routeFileNames = array_merge($this->routeFileNames, collect($routeFileNames)->flatten()->toArray());
 
         return $this;
     }
@@ -115,10 +123,5 @@ class Package
         $this->basePath = $path;
 
         return $this;
-    }
-
-    public function shortName(): string
-    {
-        return Str::after($this->name, 'laravel-');
     }
 }

--- a/tests/PackageServiceProviderTests/PackageCommandsTest.php
+++ b/tests/PackageServiceProviderTests/PackageCommandsTest.php
@@ -3,8 +3,10 @@
 namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
 
 use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\Tests\TestClasses\FourthTestCommand;
 use Spatie\LaravelPackageTools\Tests\TestClasses\OtherTestCommand;
 use Spatie\LaravelPackageTools\Tests\TestClasses\TestCommand;
+use Spatie\LaravelPackageTools\Tests\TestClasses\ThirdTestCommand;
 
 class PackageCommandsTest extends PackageServiceProviderTestCase
 {
@@ -13,7 +15,8 @@ class PackageCommandsTest extends PackageServiceProviderTestCase
         $package
             ->name('laravel-package-tools')
             ->hasCommand(TestCommand::class)
-            ->hasCommands([OtherTestCommand::class]);
+            ->hasCommands([OtherTestCommand::class])
+            ->hasCommands(ThirdTestCommand::class, FourthTestCommand::class);
     }
 
     /** @test */

--- a/tests/PackageServiceProviderTests/PackageMigrationsTest.php
+++ b/tests/PackageServiceProviderTests/PackageMigrationsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\TestTime\TestTime;
+
+class PackageMigrationsTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
+
+        $package
+            ->name('laravel-package-tools')
+            ->hasMigrations(['create_laravel_package_tools_table'])
+            ->hasMigrations('create_other_laravel_package_tools_table', 'create_third_laravel_package_tools_table');
+    }
+
+    /** @test */
+    public function it_can_publish_the_migration()
+    {
+        $this
+            ->artisan('vendor:publish --tag=laravel-package-tools-migrations')
+            ->assertExitCode(0);
+
+        $this->assertFileExists(database_path('migrations/2020_01_01_000000_create_laravel_package_tools_table.php'));
+        $this->assertFileExists(database_path('migrations/2020_01_01_000000_create_other_laravel_package_tools_table.php'));
+        $this->assertFileExists(database_path('migrations/2020_01_01_000000_create_third_laravel_package_tools_table.php'));
+    }
+}

--- a/tests/PackageServiceProviderTests/PackageRoutesTest.php
+++ b/tests/PackageServiceProviderTests/PackageRoutesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\TestTime\TestTime;
+
+class PackageRoutesTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
+
+        $package
+            ->name('laravel-package-tools')
+            ->hasRoutes('web', 'other');
+    }
+
+    /** @test */
+    public function it_can_load_the_route()
+    {
+        $response = $this->get('my-route');
+
+        $response->assertSeeText('my response');
+    }
+
+    /** @test */
+    public function it_can_load_multiple_route()
+    {
+        $adminResponse = $this->get('other-route');
+
+        $adminResponse->assertSeeText('other response');
+    }
+}

--- a/tests/TestClasses/FourthTestCommand.php
+++ b/tests/TestClasses/FourthTestCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\TestClasses;
+
+use Illuminate\Console\Command;
+
+class FourthTestCommand extends Command
+{
+    public $name = 'fourth-test-command';
+
+    public function handle()
+    {
+        $this->info('output of test command');
+    }
+}

--- a/tests/TestClasses/ThirdTestCommand.php
+++ b/tests/TestClasses/ThirdTestCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\TestClasses;
+
+use Illuminate\Console\Command;
+
+class ThirdTestCommand extends Command
+{
+    public $name = 'third-test-command';
+
+    public function handle()
+    {
+        $this->info('output of test command');
+    }
+}

--- a/tests/TestPackage/database/migrations/create_other_laravel_package_tools_table.php.stub
+++ b/tests/TestPackage/database/migrations/create_other_laravel_package_tools_table.php.stub
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLaravelPackageToolsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('other-laravel-package-tools_table', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/TestPackage/database/migrations/create_third_laravel_package_tools_table.php.stub
+++ b/tests/TestPackage/database/migrations/create_third_laravel_package_tools_table.php.stub
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLaravelPackageToolsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('third-laravel-package-tools_table', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
Howdy!

Awesome package as always guys. Whilst working with the package, it came to my attention that because of the level this package works at, methods like `hasCommands` and `hasMigrations` tend to have statically declared parameters rather than bringing in the values from another method or config file. As such, I thought it would be a nice touch to allow for parameters to be passed in varadically as well as in an array. 

Take the `hasCommands` method. Currently, you have to pass in parameters inside an array, like so:

```php
$this->hasCommands([Command::class, OtherCommand::class]);
```

As an alternate syntax, this PR enables you to get rid of the array declaration, like so:

```php
$this->hasCommands(Command::class, OtherCommand::class);
```

Because of how it works, it would also allow for syntax as such:

```php
$this->hasCommands(Command::class, [OtherCommand::class, ThirdCommand::class]);
```

This would allow for a nice mixture of varadic parameter declaration and parameters pulled in from another function:

```php
$this->hasCommands(Command::class, $this->getConfigCommands());
```

This PR adds varadic parameters to the following methods:

- hasCommands
- hasRoutes
- hasMigrations

Thanks guys! 