### PR TITLE
Fix publish view directory

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -49,7 +49,7 @@ abstract class PackageServiceProvider extends ServiceProvider
 
             if ($this->package->hasViews) {
                 $this->publishes([
-                    $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->name}"),
+                    $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->shortName()}"),
                 ], "{$this->package->name}-views");
             }
 

--- a/tests/PackageServiceProviderTests/PackageViewsTest.php
+++ b/tests/PackageServiceProviderTests/PackageViewsTest.php
@@ -28,6 +28,6 @@ class PackageViewsTest extends PackageServiceProviderTestCase
             ->artisan('vendor:publish --tag=laravel-package-tools-views')
             ->assertExitCode(0);
 
-        $this->assertFileExists(base_path('resources/views/vendor/laravel-package-tools/test.blade.php'));
+        $this->assertFileExists(base_path('resources/views/vendor/package-tools/test.blade.php'));
     }
 }


### PR DESCRIPTION
Thanks for this package, it's really nice! I'm using it and found a little issue when publishing views:

they are loaded from a directory using shortname (`$this->package->shortName()`):

```php
if ($this->package->hasViews) {
    $this->loadViewsFrom($this->package->basePath('/../resources/views'), $this->package->shortName());
}
```

but they are published to a directory with the complete package name:

```php
if ($this->package->hasViews) {
    $this->publishes([
        $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->name}"),
    ], "{$this->package->name}-views");
}
```
