### PR TITLE
Add view component support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Here's an example of how it can be used.
 ```php
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPackageTools\Package;
+use MyPackage\ViewComponents\Alert;
 
 class YourPackageServiceProvider extends PackageServiceProvider
 {
@@ -21,6 +22,7 @@ class YourPackageServiceProvider extends PackageServiceProvider
             ->name('your-package-name')
             ->hasConfigFile()
             ->hasViews()
+            ->hasViewComponent('spatie', Alert::class)
             ->hasTranslations()
             ->hasAssets()
             ->hasRoute('web')
@@ -107,6 +109,28 @@ Calling `hasViews` will also make views publishable. Users of your package will 
 
 ```bash
 php artisan vendor:publish --tag=your-package-name-views
+```
+
+### Working with view components
+
+Any Views Components that your package provides should be placed in the `<package root>/Components` directory.
+
+You can register these views with the `hasViewComponents` command.
+
+```php
+$package
+    ->name('your-package-name')
+    ->hasViewComponents('spatie', [Alert::class]);
+```
+
+This will register your view components with Laravel.  In the case of `Alert::class`, it can be referenced in views as `<x-spatie-alert />`, where `spatie` is the prefix you provided during registration.
+
+Calling `hasViewComponents` will also make view components publishable, and will be published to `app/Views/Components/vendor/<package name>`. 
+
+Users of your package will be able to publish the view components with this command:
+
+```bash
+php artisan vendor:publish --tag=your-package-name-components
 ```
 
 ### Working with translations

--- a/src/Package.php
+++ b/src/Package.php
@@ -22,6 +22,8 @@ class Package
 
     public array $commands = [];
 
+    public array $viewComponents = [];
+
     public string $basePath;
 
     public function name(string $name): self
@@ -46,6 +48,22 @@ class Package
     public function hasViews(): self
     {
         $this->hasViews = true;
+
+        return $this;
+    }
+
+    public function hasViewComponent(string $prefix, string $viewComponentName): self
+    {
+        $this->viewComponents[$viewComponentName] = $prefix;
+
+        return $this;
+    }
+
+    public function hasViewComponents(string $prefix,  ...$viewComponentNames): self
+    {
+        foreach($viewComponentNames as $componentName) {
+            $this->viewComponents[$componentName] = $prefix;
+        }
 
         return $this;
     }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -88,6 +88,17 @@ abstract class PackageServiceProvider extends ServiceProvider
             $this->loadViewsFrom($this->package->basePath('/../resources/views'), $this->package->shortName());
         }
 
+        foreach($this->package->viewComponents as $componentClass => $prefix) {
+            $this->loadViewComponentsAs($prefix, [$componentClass]);
+        }
+
+        if (count($this->package->viewComponents)) {
+            $this->publishes([
+                $this->package->basePath('/../Components') => base_path("app/View/Components/vendor/{$this->package->shortName()}"),
+            ], "{$this->package->name}-components");
+        }
+
+
         foreach ($this->package->routeFileNames as $routeFileName) {
             $this->loadRoutesFrom("{$this->package->basePath('/../routes/')}{$routeFileName}.php");
         }

--- a/tests/PackageServiceProviderTests/PackageViewComponentsTest.php
+++ b/tests/PackageServiceProviderTests/PackageViewComponentsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\Tests\TestPackage\Components\TestComponent;
+
+class PackageViewComponentsTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasViews()
+            ->hasViewComponent('abc', TestComponent::class);
+    }
+
+    /** @test */
+    public function it_can_load_the_view_components()
+    {
+        $content = view('package-tools::component-test')->render();
+
+        $this->assertStringStartsWith('<div>hello world</div>', $content);
+    }
+
+    /** @test */
+    public function it_can_publish_the_view_components()
+    {
+        $this
+            ->artisan('vendor:publish --tag=laravel-package-tools-components')
+            ->assertExitCode(0);
+
+        $this->assertFileExists(base_path('app/View/Components/vendor/package-tools/TestComponent.php'));
+    }
+}

--- a/tests/TestPackage/Components/TestComponent.php
+++ b/tests/TestPackage/Components/TestComponent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\TestPackage\Components;
+
+use Illuminate\View\Component;
+
+class TestComponent extends Component
+{
+    public $message;
+
+    /**
+     * Create the component instance.
+     *
+     * @param  string  $message
+     * @return void
+     */
+    public function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|\Closure|string
+     */
+    public function render()
+    {
+         return '<div>' . $this->message . '</div>';
+    }
+}

--- a/tests/TestPackage/resources/views/component-test.blade.php
+++ b/tests/TestPackage/resources/views/component-test.blade.php
@@ -1,0 +1,1 @@
+<x-abc-test-component message="hello world"/>


### PR DESCRIPTION
This PR adds support for [View Components](https://laravel.com/docs/8.x/packages#view-components), including publishing them as assets.  It also includes related tests and an updated readme section on using View Components.