### PR TITLE
View composers & shared view data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ class YourPackageServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasViews()
             ->hasViewComponent('spatie', Alert::class)
+            ->hasViewComposer('*', MyViewComposer::class)
+            ->sharesDataWithAllViews('downloads', 3)
             ->hasTranslations()
             ->hasAssets()
             ->hasRoute('web')
@@ -111,6 +113,16 @@ Calling `hasViews` will also make views publishable. Users of your package will 
 php artisan vendor:publish --tag=your-package-name-views
 ```
 
+### Sharing global data with views
+
+You can share data with all views using the `sharesDataWithAllViews` method.  This will make the shared variable available to all views.
+
+```php
+$package
+    ->name('your-package-name')
+    ->sharesDataWithAllViews('companyName', 'Spatie');
+```
+
 ### Working with Blade view components
 
 Any Blade view components that your package provides should be placed in the `<package root>/Components` directory.
@@ -131,6 +143,21 @@ Users of your package will be able to publish the view components with this comm
 
 ```bash
 php artisan vendor:publish --tag=your-package-name-components
+```
+
+### Working with view composers
+
+You can register any view composers that your project uses with the `hasViewComposers` method.  You may also register a callback that receives a `$view` argument instead of a classname.
+
+To register a view composer with all views, use an asterisk as the view name `'*'`.
+
+```php
+$package
+    ->name('your-package-name')
+    ->hasViewComposer('viewName', MyViewComposer::class)
+    ->hasViewComposer('*', function($view) { 
+        $view->with('sharedVariable', 123); 
+    });
 ```
 
 ### Working with translations

--- a/src/Package.php
+++ b/src/Package.php
@@ -24,6 +24,10 @@ class Package
 
     public array $viewComponents = [];
 
+    public array $sharedViewData = [];
+
+    public array $viewComposers = [];
+
     public string $basePath;
 
     public function name(string $name): self
@@ -63,6 +67,26 @@ class Package
     {
         foreach ($viewComponentNames as $componentName) {
             $this->viewComponents[$componentName] = $prefix;
+        }
+
+        return $this;
+    }
+
+    public function sharesDataWithAllViews(string $name, $value): self
+    {
+        $this->sharedViewData[$name] = $value;
+
+        return $this;
+    }
+
+    public function hasViewComposer($view, $viewComposer): self
+    {
+        if (!is_array($view)) {
+            $view = [$view];
+        }
+
+        foreach($view as $viewName) {
+            $this->viewComposers[$viewName] = $viewComposer;
         }
 
         return $this;

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelPackageTools;
 
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -101,6 +102,14 @@ abstract class PackageServiceProvider extends ServiceProvider
 
         foreach ($this->package->routeFileNames as $routeFileName) {
             $this->loadRoutesFrom("{$this->package->basePath('/../routes/')}{$routeFileName}.php");
+        }
+
+        foreach($this->package->sharedViewData as $name => $value) {
+            View::share($name, $value);
+        }
+
+        foreach($this->package->viewComposers as $viewName => $viewComposer) {
+            View::composer($viewName, $viewComposer);
         }
 
         $this->packageBooted();

--- a/tests/PackageServiceProviderTests/PackageSharedDataTest.php
+++ b/tests/PackageServiceProviderTests/PackageSharedDataTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+
+class PackageSharedDataTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasViews()
+            ->sharesDataWithAllViews('sharedItemTest', 'hello_world');
+    }
+
+    /** @test */
+    public function it_can_share_data_with_all_views()
+    {
+        $content1 = view('package-tools::shared-data')->render();
+        $content2 = view('package-tools::shared-data-2')->render();
+
+        $this->assertStringStartsWith('hello_world', $content1);
+        $this->assertStringStartsWith('hello_world', $content2);
+    }
+}

--- a/tests/PackageServiceProviderTests/PackageViewComposerTest.php
+++ b/tests/PackageServiceProviderTests/PackageViewComposerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+
+class PackageViewComposerTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasViews()
+            ->hasViewComposer('*', function($view) {
+                $view->with('sharedItemTest', 'hello world');
+            });
+    }
+
+    /** @test */
+    public function it_can_load_the_view_composer_and_render_shared_data()
+    {
+        $content = view('package-tools::shared-data')->render();
+
+        $this->assertStringStartsWith('hello world', $content);
+    }
+}

--- a/tests/TestPackage/resources/views/shared-data-2.blade.php
+++ b/tests/TestPackage/resources/views/shared-data-2.blade.php
@@ -1,0 +1,1 @@
+{{ $sharedItemTest }}

--- a/tests/TestPackage/resources/views/shared-data.blade.php
+++ b/tests/TestPackage/resources/views/shared-data.blade.php
@@ -1,0 +1,1 @@
+{{ $sharedItemTest }}


### PR DESCRIPTION
This PR adds two features related to view data: view composers and sharing data globally with all views.  It adds two methods, `hasViewComposer()` and `sharesDataWithAllViews()`.

- `hasViewComposer()` registers either a [view composer](https://laravel.com/docs/8.x/views#view-composers) class or a callback.
- `sharesDataWithAllViews()` makes the specified variable name [available to all views](https://laravel.com/docs/8.x/views#sharing-data-with-all-views).

I feel that these additions will help keep Laravel package setup code clean and easy to maintain, with no real downside to having these additional methods available even if they're not used for every package.

This PR also includes relevant unit tests and updated documentation.