### PR TITLE
Execute command in context of the app

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -74,7 +74,9 @@ abstract class PackageServiceProvider extends ServiceProvider
                     $this->package->basePath('/../resources/dist') => public_path("vendor/{$this->package->shortName()}"),
                 ], "{$this->package->shortName()}-assets");
             }
+        }
 
+        if (!empty($this->package->commands)) {
             $this->commands($this->package->commands);
         }
 

--- a/tests/PackageServiceProviderTests/PackageCommandWithinAppTest.php
+++ b/tests/PackageServiceProviderTests/PackageCommandWithinAppTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\Tests\TestClasses\TestCommand;
+
+class PackageCommandWithinAppTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasRoutes('web')
+            ->hasCommand(TestCommand::class);
+    }
+
+    /** @test */
+    public function it_can_execute_a_registered_command_in_the_context_of_the_app()
+    {
+        $response = $this->get('execute-command');
+
+        $response->assertSee('output of test command');
+    }
+}

--- a/tests/TestPackage/routes/web.php
+++ b/tests/TestPackage/routes/web.php
@@ -1,5 +1,11 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 
 Route::get('my-route', fn () => 'my response');
+
+Route::get('execute-command', function () {
+    Artisan::call('test-command');
+    return Artisan::output();
+});


### PR DESCRIPTION
This PR moves command registration outside the console context so that we can execute Artisan commands programmatically within the context of the application.

This change will resolve an issue I was having with the MultiTenancy package here: https://github.com/spatie/laravel-multitenancy/issues/207

I have added supporting tests to prove the functionality works as expected but I am happy to continue working on this if anyone has any feedback or change requests.

Thanks