### PR TITLE
Add feature to register middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $package
 
 This will register your view components with Laravel.  In the case of `Alert::class`, it can be referenced in views as `<x-spatie-alert />`, where `spatie` is the prefix you provided during registration.
 
-Calling `hasViewComponents` will also make view components publishable, and will be published to `app/Views/Components/vendor/<package name>`. 
+Calling `hasViewComponents` will also make view components publishable, and will be published to `app/Views/Components/vendor/<package name>`.
 
 Users of your package will be able to publish the view components with this command:
 
@@ -155,8 +155,8 @@ To register a view composer with all views, use an asterisk as the view name `'*
 $package
     ->name('your-package-name')
     ->hasViewComposer('viewName', MyViewComposer::class)
-    ->hasViewComposer('*', function($view) { 
-        $view->with('sharedVariable', 123); 
+    ->hasViewComposer('*', function($view) {
+        $view->with('sharedVariable', 123);
     });
 ```
 
@@ -223,7 +223,7 @@ This will copy over the assets to the `public/vendor/<your-package-name>` direct
 
 The `PackageServiceProvider` assumes that any migrations are placed in this directory: `<package root>/database/migrations`. Inside that directory you can put any migrations. Make sure they all have a `php.stub` extension. Using that extension will make sure that static analysers won't get confused with classes existing in multiple places when your migration gets published.
 
-To register your migration, you should pass its name without the extension to the `hasMigration` table. 
+To register your migration, you should pass its name without the extension to the `hasMigration` table.
 
 If your migration file is called `create_my_package_tables.php.stub` you can register them like this:
 
@@ -274,7 +274,7 @@ $package
 
 The `PackageServiceProvider` assumes that any route files are placed in this directory: `<package root>/routes`. Inside that directory you can put any route files.
 
-To register your route, you should pass its name without the extension to the `hasRoute` method. 
+To register your route, you should pass its name without the extension to the `hasRoute` method.
 
 If your route file is called `web.php` you can register them like this:
 
@@ -292,11 +292,33 @@ $package
     ->hasRoutes(['web', 'admin']);
 ```
 
+
+### Working with middlewares
+
+You can put middleware anywhere in your package. But we recommend to put in this directory: `<package root>/src/Http/Middleware`.
+
+Then register it with `hasMiddlewares` method.
+
+```php
+$package
+    ->name('your-package-name')
+    ->hasMiddlewares([
+        'gogogo' => PeopleWontStopMeButMiddlewareWill::class,
+    ]);
+```
+
+... your package and users will be able to use the middleware with:
+
+```php
+Route::middleware('your-package-name.gogogo'); //...
+Route::group(['middleware' => 'your-package-name.gogogo']); //...
+```
+
 ### Using lifecycle hooks
 
 You can put any custom logic your package needs while starting up in one of these methods:
 
-- `registeringPackage`: will be called at the start of the `register` method of `PackageServiceProvider` 
+- `registeringPackage`: will be called at the start of the `register` method of `PackageServiceProvider`
 - `packageRegistered`: will be called at the end of the `register` method of `PackageServiceProvider`
 - `bootingPackage`: will be called at the start of the `boot` method of `PackageServiceProvider`
 - `packageBooted`: will be called at the end of the `boot` method of `PackageServiceProvider`

--- a/src/Package.php
+++ b/src/Package.php
@@ -28,6 +28,8 @@ class Package
 
     public array $viewComposers = [];
 
+    public array $middlewares = [];
+
     public string $basePath;
 
     public function name(string $name): self
@@ -147,6 +149,13 @@ class Package
     public function hasRoutes(...$routeFileNames): self
     {
         $this->routeFileNames = array_merge($this->routeFileNames, collect($routeFileNames)->flatten()->toArray());
+
+        return $this;
+    }
+
+    public function hasMiddlewares(array $middlewares): self
+    {
+        $this->middlewares = array_merge($this->middlewares, $middlewares);
 
         return $this;
     }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelPackageTools;
 
+use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -112,6 +113,11 @@ abstract class PackageServiceProvider extends ServiceProvider
 
         foreach ($this->package->viewComposers as $viewName => $viewComposer) {
             View::composer($viewName, $viewComposer);
+        }
+
+        $router = $this->app->make(Router::class);
+        foreach($this->package->middlewares as $alias => $middleware) {
+            $router->aliasMiddleware("{$this->package->name}.{$alias}", $middleware);
         }
 
         $this->packageBooted();

--- a/tests/PackageServiceProviderTests/PackageMiddlewaresTest.php
+++ b/tests/PackageServiceProviderTests/PackageMiddlewaresTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Illuminate\Http\Response;
+use Illuminate\Routing\Router;
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\Tests\TestPackage\Http\Middleware\PeopleWontStopMeButMiddlewareWill;
+
+class PackageMiddlewaresTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasMiddlewares([
+                'gogogo' => PeopleWontStopMeButMiddlewareWill::class,
+            ]);
+    }
+
+    /** @test */
+    public function it_can_register_package_middlewares()
+    {
+        $router = $this->app->make(Router::class);
+
+        $router->get('/welcome-to-my-precious-hidden-gem')
+            ->middleware('laravel-package-tools.gogogo');
+
+        $this->get('/welcome-to-my-precious-hidden-gem')
+            ->assertStatus(Response::HTTP_EXPECTATION_FAILED);
+
+        $router->group(['middleware' => 'laravel-package-tools.gogogo'], function() use ($router) {
+            $router->get('/lets-try-again');
+        });
+
+        $this->get('/lets-try-again')
+            ->assertStatus(Response::HTTP_EXPECTATION_FAILED);
+    }
+}

--- a/tests/TestPackage/Http/Middleware/PeopleWontStopMeButMiddlewareWill.php
+++ b/tests/TestPackage/Http/Middleware/PeopleWontStopMeButMiddlewareWill.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\TestPackage\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Response;
+
+class PeopleWontStopMeButMiddlewareWill
+{
+    /**
+     * A tragic middleware who ends my hope.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($sorryMateYouCantGoAnyFurther = true) {
+            abort(Response::HTTP_EXPECTATION_FAILED);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Looking a way to register package middlewares but only found this discussion https://github.com/spatie/laravel-package-tools/discussions/6. @freekmurze says PR are welcome.

Here is my first PR 🚀️

It allows package creator to register their middlewares like this:

```php
$package
    ->name('your-package-name')
    ->hasMiddlewares([
        'gogogo' => PeopleWontStopMeButMiddlewareWill::class,
    ]);
```

... then the users will be able to use the middleware with:

```php
Route::middleware('your-package-name.gogogo'); //...
Route::group(['middleware' => 'your-package-name.gogogo']); //...
```

Note:
- i already tried using `::` instaed of `.` but it always failed because of class namespace resolution.
- thanks to https://laravelpackage.com/11-middleware.html#route-middleware 

