### PR TITLE
Fix migration file names when copying them

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -59,7 +59,7 @@ abstract class PackageServiceProvider extends ServiceProvider
             foreach ($this->package->migrationFileNames as $migrationFileName) {
                 if (! $this->migrationFileExists($migrationFileName)) {
                     $this->publishes([
-                        $this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => database_path('migrations/' . $now->addSecond()->format('Y_m_d_His') . '_' . Str::finish($migrationFileName, '.php')),
+                        $this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => database_path('migrations/' . $now->addSecond()->format('Y_m_d_His') . '_' . Str::of($migrationFileName)->snake()->finish('.php')),
                     ], "{$this->package->shortName()}-migrations");
                 }
             }


### PR DESCRIPTION
Per: #27 here and https://github.com/spatie/laravel-activitylog/pull/876
This PR will ensure migrations use expected file names once they are copied.

Before:
```
Copied File [/vendor/spatie/laravel-activitylog/migrations/AddBatchUuidColumnToActivityLogTable.php.stub] To [/database/migrations/2021_04_26_212134_AddBatchUuidColumnToActivityLogTable.php]
```

Now:
```
Copied File [/vendor/spatie/laravel-activitylog/migrations/AddBatchUuidColumnToActivityLogTable.php.stub] To [/database/migrations/2021_04_26_212425_add_batch_uuid_column_to_activity_log_table.php]
```