### PR TITLE
Add json translations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,23 @@ trans('your-package-name::translations.translatable'); // returns 'translation'
 
 If your package name starts with `laravel-` then you should leave that off in the example above.
 
+Coding with translation strings as keys, you should create JSON files in `<package root>/resources/lang/<language-code>.json`.
+
+For example, creating `<package root>/resources/lang/it.json` file like so:
+
+```json
+{
+    "Hello!": "Ciao!"
+}
+```
+
+...the output of...
+
+```php
+trans('Hello!');
+``` 
+
+...will be `Ciao!` if the application uses the Italian language.  
 
 Calling `hasTranslations` will also make translations publishable. Users of your package will be able to publish the translations with this command:
 

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -95,6 +95,9 @@ abstract class PackageServiceProvider extends ServiceProvider
                 $this->package->basePath('/../resources/lang/'),
                 $this->package->shortName()
             );
+
+            $this->loadJsonTranslationsFrom($this->package->basePath('/../resources/lang/'));
+            $this->loadJsonTranslationsFrom(resource_path('lang/vendor/'. $this->package->name));
         }
 
         if ($this->package->hasViews) {

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -97,7 +97,7 @@ abstract class PackageServiceProvider extends ServiceProvider
             );
 
             $this->loadJsonTranslationsFrom($this->package->basePath('/../resources/lang/'));
-            $this->loadJsonTranslationsFrom(resource_path('lang/vendor/'. $this->package->name));
+            $this->loadJsonTranslationsFrom(resource_path('lang/vendor/'. $this->package->shortName()));
         }
 
         if ($this->package->hasViews) {


### PR DESCRIPTION
I have verified currently the package doesn't allow to works with JSON translations.

The PR enables the support to JSON translation files, loading files from the package directory itself or, when available, from the `resource/vendor/package-name/` directory (needed if a customer likes to override the translations).