### PR TITLE
Changed components directory path so it is on the same level of the package's service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here's an example of how it can be used.
 ```php
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPackageTools\Package;
-use MyPackage\ViewComponents\Alert;
+use MyPackage\Components\Alert;
 
 class YourPackageServiceProvider extends PackageServiceProvider
 {

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -110,7 +110,7 @@ abstract class PackageServiceProvider extends ServiceProvider
 
         if (count($this->package->viewComponents)) {
             $this->publishes([
-                $this->package->basePath('/../Components') => base_path("app/View/Components/vendor/{$this->package->shortName()}"),
+                $this->package->basePath('/Components') => base_path("app/View/Components/vendor/{$this->package->shortName()}"),
             ], "{$this->package->name}-components");
         }
 

--- a/tests/PackageServiceProviderTests/PackageViewComponentsTest.php
+++ b/tests/PackageServiceProviderTests/PackageViewComponentsTest.php
@@ -3,7 +3,7 @@
 namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
 
 use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\Tests\TestPackage\Components\TestComponent;
+use Spatie\LaravelPackageTools\Tests\TestPackage\Src\Components\TestComponent;
 
 class PackageViewComponentsTest extends PackageServiceProviderTestCase
 {

--- a/tests/TestPackage/Src/Components/TestComponent.php
+++ b/tests/TestPackage/Src/Components/TestComponent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\LaravelPackageTools\Tests\TestPackage\Components;
+namespace Spatie\LaravelPackageTools\Tests\TestPackage\Src\Components;
 
 use Illuminate\View\Component;
 


### PR DESCRIPTION
After a brief discussion i've changed the publish path of the components directory to be on the same level of the package's service provider.

I've chosen for the path to be on the same level since it's documented that way in the laravel documentation https://laravel.com/docs/8.x/packages#view-components

For packages already using this package, i think it'll be a breaking change