### PR TITLE
Allow to re-publish migrations via artisan --force

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -55,10 +55,12 @@ abstract class PackageServiceProvider extends ServiceProvider
                 ], "{$this->package->shortName()}-views");
             }
 
+            $now = Carbon::now();
             foreach ($this->package->migrationFileNames as $migrationFileName) {
                 $this->publishes([
-                    $this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => $this->generateMigrationName($migrationFileName),
-                ], "{$this->package->shortName()}-migrations");
+                    $this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => $this->generateMigrationName(
+                        $migrationFileName, $now->addSecond()
+                )], "{$this->package->shortName()}-migrations");
             }
 
             if ($this->package->hasTranslations) {
@@ -120,21 +122,20 @@ abstract class PackageServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function generateMigrationName(string $migrationFileName): string
+    public function generateMigrationName(string $migrationFileName, Carbon $now): string
     {
         if($existing = $this->existingMigrationFileName($migrationFileName)) {
             return $existing;
         }
 
         $migrationPath = 'migrations/';
-        $now = Carbon::now();
 
         if (Str::contains($migrationFileName, '/')) {
             $migrationPath .= Str::of($migrationFileName)->beforeLast('/')->finish('/');
             $migrationFileName = Str::of($migrationFileName)->afterLast('/');
         }
 
-        return database_path($migrationPath . $now->addSecond()->format('Y_m_d_His') . '_' . Str::of($migrationFileName)->snake()->finish('.php'));
+        return database_path($migrationPath . $now->format('Y_m_d_His') . '_' . Str::of($migrationFileName)->snake()->finish('.php'));
     }
 
     public static function existingMigrationFileName(string $migrationFileName): ?string

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -122,23 +122,7 @@ abstract class PackageServiceProvider extends ServiceProvider
         return $this;
     }
 
-    public function generateMigrationName(string $migrationFileName, Carbon $now): string
-    {
-        if($existing = $this->existingMigrationFileName($migrationFileName)) {
-            return $existing;
-        }
-
-        $migrationPath = 'migrations/';
-
-        if (Str::contains($migrationFileName, '/')) {
-            $migrationPath .= Str::of($migrationFileName)->beforeLast('/')->finish('/');
-            $migrationFileName = Str::of($migrationFileName)->afterLast('/');
-        }
-
-        return database_path($migrationPath . $now->format('Y_m_d_His') . '_' . Str::of($migrationFileName)->snake()->finish('.php'));
-    }
-
-    public static function existingMigrationFileName(string $migrationFileName): ?string
+    public static function generateMigrationName(string $migrationFileName, Carbon $now): string
     {
         $migrationsPath = 'migrations/';
 
@@ -155,7 +139,7 @@ abstract class PackageServiceProvider extends ServiceProvider
             }
         }
 
-        return null;
+        return database_path($migrationsPath . $now->format('Y_m_d_His') . '_' . Str::of($migrationFileName)->snake()->finish('.php'));
     }
 
     public function registeringPackage()

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -59,8 +59,9 @@ abstract class PackageServiceProvider extends ServiceProvider
             foreach ($this->package->migrationFileNames as $migrationFileName) {
                 $this->publishes([
                     $this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => $this->generateMigrationName(
-                        $migrationFileName, $now->addSecond()
-                )], "{$this->package->shortName()}-migrations");
+                        $migrationFileName,
+                        $now->addSecond()
+                    ), ], "{$this->package->shortName()}-migrations");
             }
 
             if ($this->package->hasTranslations) {

--- a/tests/PackageServiceProviderTests/PackageMigrationTest.php
+++ b/tests/PackageServiceProviderTests/PackageMigrationTest.php
@@ -25,4 +25,47 @@ class PackageMigrationTest extends PackageServiceProviderTestCase
 
         $this->assertFileExists(database_path('migrations/2020_01_01_000001_create_another_laravel_package_tools_table.php'));
     }
+
+    /** @test */
+    public function it_does_not_overwrite_the_existing_migration()
+    {
+        $this
+            ->artisan('vendor:publish --tag=package-tools-migrations')
+            ->assertExitCode(0);
+
+        $filePath = database_path('migrations/2020_01_01_000001_create_another_laravel_package_tools_table.php');
+
+        $this->assertFileExists($filePath);
+
+        file_put_contents($filePath, 'modified');
+
+        $this
+            ->artisan('vendor:publish --tag=package-tools-migrations')
+            ->assertExitCode(0);
+
+        $this->assertStringEqualsFile($filePath, 'modified');
+    }
+
+    /** @test */
+    public function it_does_overwrite_the_existing_migration_with_force()
+    {
+        $this
+            ->artisan('vendor:publish --tag=package-tools-migrations')
+            ->assertExitCode(0);
+
+        $filePath = database_path('migrations/2020_01_01_000001_create_another_laravel_package_tools_table.php');
+
+        $this->assertFileExists($filePath);
+
+        file_put_contents($filePath, 'modified');
+
+        $this
+            ->artisan('vendor:publish --tag=package-tools-migrations  --force')
+            ->assertExitCode(0);
+
+        $this->assertStringEqualsFile(
+            $filePath,
+            file_get_contents(__DIR__.'/../TestPackage/database/migrations/create_another_laravel_package_tools_table.php.stub')
+        );
+    }
 }


### PR DESCRIPTION
When registering migration files for publishing, the current implementation checks whether a migration file for a given name already exists/has been published before. If such a file exists, the package does not register that migration for publishing. 

By that we lose the ability to run `artisan vendor:publish --force` to get the latest versions of all migrations. You'd have to delete the existing migrations manually first and then run `vendor:publish` again.

With this PR, the `--force` flag will also re-publish the migrations while keeping any existing file names in place. 