### PR TITLE
move mockery to dev deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/contracts": "^7.0|^8.0",
-        "mockery/mockery": "^1.4"
+        "illuminate/contracts": "^7.0|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0|^6.0",
         "phpunit/phpunit": "^9.3",
-        "spatie/test-time": "^1.2"
+        "spatie/test-time": "^1.2",
+        "mockery/mockery": "^1.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Noticed how our composer install --no-dev included mockery, after some digging around we found that mockery is not installed as a dev dependency in this package.