### PR TITLE
Corrected error in hasViewComponents() docs...

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ You can register these views with the `hasViewComponents` command.
 ```php
 $package
     ->name('your-package-name')
-    ->hasViewComponents('spatie', [Alert::class]);
+    ->hasViewComponents('spatie', Alert::class);
 ```
 
 This will register your view components with Laravel.  In the case of `Alert::class`, it can be referenced in views as `<x-spatie-alert />`, where `spatie` is the prefix you provided during registration.


### PR DESCRIPTION
The docs state that one should pass an array of view component classes to `hasViewComponents()` when, in fact, it simply requires a list of one or more view component class arguments...after the prefix, of course.

I noticed this when passing an array, per the docs, and the package would attempt to iterate over the `...$viewComponentNames` arguments, but there was only one, which was an array, which then caused an exception when trying to use it as an array index.

So...easy-peasy change....unless I've missed something. 🤓