### PR TITLE
hasMiddleware() feature added + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ class YourPackageServiceProvider extends PackageServiceProvider
             ->hasAssets()
             ->hasRoute('web')
             ->hasMigration('create_package_tables')
+            ->hasMiddleware(MyMiddleware::class, 'web')
             ->hasCommand(YourCoolPackageCommand::class);
     }
 }
@@ -294,6 +295,35 @@ $package
         YourCoolPackageCommand::class,
         YourOtherCoolPackageCommand::class,
     ]);
+```
+
+### Registering middlewares
+
+You can register any middleware your package provides with the `hasMiddleware` function.
+
+Add your middleware globally or only to a specific middleware group by adding the group parameter. (e.g. 'web', 'api')
+
+```php
+// Adds a global middleware.
+$package
+    ->name('your-package-name')
+    ->hasMiddleware(MyMiddleware::class)
+
+// Adds a middleware to the middleware group 'api' only.
+$package
+    ->name('your-package-name')
+    ->hasMiddleware(MyMiddleware::class, 'api')
+````
+
+If your package provides multiple middlewares, you can either use `hasMiddleware` multiple times, or pass an array to `hasMiddlewares`. You can apply a specific middleware group to both methods.
+
+```php
+$package
+    ->name('your-package-name')
+    ->hasMiddlewares([
+        MyMiddleware::class,
+        AnotherMiddleware::class,
+    ], 'web');
 ```
 
 ### Working with routes

--- a/src/Package.php
+++ b/src/Package.php
@@ -69,7 +69,7 @@ class Package
         return $this;
     }
 
-    public function hasViewComponents(string $prefix,  ...$viewComponentNames): self
+    public function hasViewComponents(string $prefix, ...$viewComponentNames): self
     {
         foreach ($viewComponentNames as $componentName) {
             $this->viewComponents[$componentName] = $prefix;
@@ -139,6 +139,28 @@ class Package
     public function hasCommands(...$commandClassNames): self
     {
         $this->commands = array_merge($this->commands, collect($commandClassNames)->flatten()->toArray());
+
+        return $this;
+    }
+
+    public function hasMiddleware(string $middleware, string $middlewareGroup = null): self
+    {
+        $kernel = app(\Illuminate\Contracts\Http\Kernel::class);
+
+        if ($middlewareGroup) {
+            $kernel->prependMiddlewareToGroup($middlewareGroup, $middleware);
+        } else {
+            $kernel->pushMiddleware($middleware);
+        }
+
+        return $this;
+    }
+
+    public function hasMiddlewares(array $middlewareClassNames, string $middlewareGroup = null): self
+    {
+        collect($middlewareClassNames)->each(
+            fn ($middlewareClassName) => $this->hasMiddleware($middlewareClassName, $middlewareGroup)
+        );
 
         return $this;
     }

--- a/tests/PackageServiceProviderTests/PackageMiddlewareGroupTest.php
+++ b/tests/PackageServiceProviderTests/PackageMiddlewareGroupTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\Tests\TestPackage\Src\Middleware\TestMiddleware;
+use Spatie\TestTime\TestTime;
+
+class PackageMiddlewareGroupTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasRoutes('web', 'api')
+            ->hasMiddleware(TestMiddleware::class, 'api');
+    }
+
+    /** @test */
+    public function it_registers_group_middleware()
+    {
+        $response = $this->get('api-route');
+
+        $response->assertSeeText('test-middleware-content');
+
+        $response = $this->get('my-route');
+
+        $response->assertDontSeeText('test-middleware-content');
+    }
+}

--- a/tests/PackageServiceProviderTests/PackageMiddlewareTest.php
+++ b/tests/PackageServiceProviderTests/PackageMiddlewareTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\Tests\TestPackage\Src\Middleware\TestMiddleware;
+use Spatie\TestTime\TestTime;
+
+class PackageMiddlewareTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasRoutes('web', 'api')
+            ->hasMiddleware(TestMiddleware::class);
+    }
+
+    /** @test */
+    public function it_registers_global_middleware()
+    {
+        $response = $this->get('api-route');
+
+        $response->assertSeeText('test-middleware-content');
+
+        $response = $this->get('my-route');
+
+        $response->assertSeeText('test-middleware-content');
+    }
+}

--- a/tests/TestPackage/Src/Middleware/TestMiddleware.php
+++ b/tests/TestPackage/Src/Middleware/TestMiddleware.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\TestPackage\Src\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class TestMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request)->setContent('test-middleware-content');
+    }
+}

--- a/tests/TestPackage/routes/api.php
+++ b/tests/TestPackage/routes/api.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('api')->group(function () {
+
+    Route::get('api-route', fn () => ['api content']);
+
+});
+


### PR DESCRIPTION
This PR adds the feature **hasMiddleware** to the laravel-package-tools. If added, the middleware automatically runs on each request. This feature allows to apply a middleware globally or only assign it to a specific middleware group.

# Features

- Allows to add a **global middleware**: `->hasMiddleware(MyMiddleware::class)`
- Allows to add a **middleware to a middleware group**: `->hasMiddleware(MyMiddleware::class, 'api')`
- Allows to add **many middlewares** at once: `->hasMiddlewares([MyMiddleware::class], 'web')`

# Info

- **Tests** for both global middleware and middleware groups are added.
- **Documentation** has been added.

# Companion PR in package-skeleton-laravel

Please also see the companion [PR in the spatie/package-skeleton-laravel](https://github.com/spatie/package-skeleton-laravel/pull/153) package which adds the middleware feature to the **configure.php** script. 

# Excerpt of the documentation.

### Registering middlewares

You can register any middleware your package provides with the `hasMiddleware` function.

Add your middleware globally or only to a specific middleware group by adding the group parameter. (e.g. 'web', 'api')

```php
// Adds a global middleware.
$package
    ->name('your-package-name')
    ->hasMiddleware(MyMiddleware::class)

// Adds a middleware to the middleware group 'api' only.
$package
    ->name('your-package-name')
    ->hasMiddleware(MyMiddleware::class, 'api')
````

If your package provides multiple middlewares, you can either use `hasMiddleware` multiple times, or pass an array to `hasMiddlewares`. You can apply a specific middleware group to both methods.

```php
$package
    ->name('your-package-name')
    ->hasMiddlewares([
        MyMiddleware::class,
        AnotherMiddleware::class,
    ], 'web');
```