### PR TITLE
Remove Database\Factories from psr-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Spatie\\LaravelPackageTools\\": "src",
-            "Spatie\\LaravelPackageTools\\Database\\Factories\\": "database/factories"
+            "Spatie\\LaravelPackageTools\\": "src"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
It looks like `Spatie\\LaravelPackageTools\\Database\\Factories\\` is not needed.

With this, I have a error when running master version of PHPStan : 
```
Fatal error: Uncaught PHPStan\BetterReflection\SourceLocator\Type\Composer\Psr\Exception\InvalidPrefixMapping: 
Provided path "Spatie\LaravelPackageTools\Database\Factories\" for prefix "/path-to-project/vendor/composer/../spatie/laravel-package-tools/database/factories" is not a directory
in phar:///path-to-project/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/SourceLocator/Type/Composer/Psr/Exception/InvalidPrefixMapping.php:20
```