### PR TITLE
Add ability to customise view namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ This will register your views with Laravel.
 
 If you have a view `<package root>/resources/views/myView.blade.php`, you can use it like this: `view('your-package-name::myView')`. Of course, you can also use subdirectories to organise your views. A view located at `<package root>/resources/views/subdirectory/myOtherView.blade.php` can be used with `view('your-package-name::subdirectory.myOtherView')`.
 
+#### Using a custom view namespace
+
+You can pass a custom view namespace to the `hasViews` method.
+
+```php
+$package
+    ->name('your-package-name')
+    ->hasViews('custom-view-namespace');
+```
+
+You can now use the views of the package like this:
+
+```php
+view('custom-view-namespace::myView');
+```
+
+#### Publishing the views
 
 Calling `hasViews` will also make views publishable. Users of your package will be able to publish the views with this command:
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -12,6 +12,8 @@ class Package
 
     public bool $hasViews = false;
 
+    public ?string $viewNamespace = null;
+
     public bool $hasTranslations = false;
 
     public bool $hasAssets = false;
@@ -29,6 +31,7 @@ class Package
     public array $viewComposers = [];
 
     public string $basePath;
+
 
     public function name(string $name): self
     {
@@ -55,9 +58,11 @@ class Package
         return Str::after($this->name, 'laravel-');
     }
 
-    public function hasViews(): self
+    public function hasViews(string $namespace = null): self
     {
         $this->hasViews = true;
+
+        $this->viewNamespace = $namespace;
 
         return $this;
     }
@@ -164,6 +169,11 @@ class Package
         }
 
         return $this->basePath . DIRECTORY_SEPARATOR . ltrim($directory, DIRECTORY_SEPARATOR);
+    }
+
+    public function viewNamespace(): string
+    {
+        return $this->viewNamespace ?? $this->shortName();
     }
 
     public function setBasePath(string $path): self

--- a/src/Package.php
+++ b/src/Package.php
@@ -32,7 +32,6 @@ class Package
 
     public string $basePath;
 
-
     public function name(string $name): self
     {
         $this->name = $name;

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -92,7 +92,7 @@ abstract class PackageServiceProvider extends ServiceProvider
         }
 
         if ($this->package->hasViews) {
-            $this->loadViewsFrom($this->package->basePath('/../resources/views'), $this->package->shortName());
+            $this->loadViewsFrom($this->package->basePath('/../resources/views'), $this->package->viewNamespace());
         }
 
         foreach ($this->package->viewComponents as $componentClass => $prefix) {

--- a/tests/PackageServiceProviderTests/PackageViewsWithCustomNamespaceTest.php
+++ b/tests/PackageServiceProviderTests/PackageViewsWithCustomNamespaceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
+
+use Spatie\LaravelPackageTools\Package;
+
+class PackageViewsWithCustomNamespaceTest extends PackageServiceProviderTestCase
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasViews('custom-namespace');
+    }
+
+    /** @test */
+    public function it_can_load_the_views_with_a_custom_namespace()
+    {
+        $content = view('custom-namespace::test')->render();
+
+        $this->assertStringStartsWith('This is a blade view', $content);
+    }
+
+    /** @test */
+    public function it_can_publish_the_views_with_a_custom_namespace()
+    {
+        $this
+            ->artisan('vendor:publish --tag=package-tools-views')
+            ->assertExitCode(0);
+
+        $this->assertFileExists(base_path('resources/views/vendor/package-tools/test.blade.php'));
+    }
+}


### PR DESCRIPTION
This PR allows passing a custom view namespace to the `hasViews` method.

```php
$package
    ->name('your-package-name')
    ->hasViews('custom-view-namespace');
```

You can now use the views of the package like this:

```php
view('custom-view-namespace::myView');
```
