### PR TITLE
Support for non-stubbed migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ This will copy over the assets to the `public/vendor/<your-package-name>` direct
 
 ### Working with migrations
 
-The `PackageServiceProvider` assumes that any migrations are placed in this directory: `<package root>/database/migrations`. Inside that directory you can put any migrations. Make sure they all have a `php.stub` extension. Using that extension will make sure that static analysers won't get confused with classes existing in multiple places when your migration gets published.
+The `PackageServiceProvider` assumes that any migrations are placed in this directory: `<package root>/database/migrations`. Inside that directory you can put any migrations.
 
 To register your migration, you should pass its name without the extension to the `hasMigration` table. 
 

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -57,8 +57,14 @@ abstract class PackageServiceProvider extends ServiceProvider
 
             $now = Carbon::now();
             foreach ($this->package->migrationFileNames as $migrationFileName) {
+                $filePath = $this->package->basePath("/../database/migrations/{$migrationFileName}.php");
+                if (! file_exists($filePath)) {
+                    // Support for the .stub file extension
+                    $filePath .= '.stub';
+                }
+
                 $this->publishes([
-                    $this->package->basePath("/../database/migrations/{$migrationFileName}.php.stub") => $this->generateMigrationName(
+                    $filePath => $this->generateMigrationName(
                         $migrationFileName,
                         $now->addSecond()
                     ), ], "{$this->package->shortName()}-migrations");

--- a/tests/PackageServiceProviderTests/PackageMigrationTest.php
+++ b/tests/PackageServiceProviderTests/PackageMigrationTest.php
@@ -13,7 +13,8 @@ class PackageMigrationTest extends PackageServiceProviderTestCase
 
         $package
             ->name('laravel-package-tools')
-            ->hasMigration('create_another_laravel_package_tools_table');
+            ->hasMigration('create_another_laravel_package_tools_table')
+            ->hasMigration('create_regular_laravel_package_tools_table');
     }
 
     /** @test */
@@ -24,6 +25,16 @@ class PackageMigrationTest extends PackageServiceProviderTestCase
             ->assertExitCode(0);
 
         $this->assertFileExists(database_path('migrations/2020_01_01_000001_create_another_laravel_package_tools_table.php'));
+    }
+
+    /** @test */
+    public function it_can_publish_the_migration_without_being_stubbed()
+    {
+        $this
+            ->artisan('vendor:publish --tag=package-tools-migrations')
+            ->assertExitCode(0);
+
+        $this->assertFileExists(database_path('migrations/2020_01_01_000002_create_regular_laravel_package_tools_table.php'));
     }
 
     /** @test */

--- a/tests/TestPackage/database/migrations/create_regular_laravel_package_tools_table.php
+++ b/tests/TestPackage/database/migrations/create_regular_laravel_package_tools_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('regular-laravel-package-tools_table', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->timestamps();
+        });
+    }
+};


### PR DESCRIPTION
Currently all migrations need to have the `.php.stub` file extension rather than the regular `.php`. The README clarifies that this is to prevent IDEs from indexing a migration class name twice when the migrations are published. There are downside to this stubbing though, like losing default IDE code highlighting and having to rename migrations after moving them from an application. This last one is annoying if you want to use `artisan make:migration` to create your migration templates. 

If I'm understanding correctly, the original indexing issue is no longer a problem when using anonymous migrations which have no class name but instead use `return new class {}`. Laravel has supported anonymous migrations for a while now (ever since Laravel 8.37) and now with Laravel 9 it is the default format for all new migrations. 

This PR adds support for files ending with `.php` without breaking backwards compatibility and contains a test. 

I'm not sure what to do about the README though. The new method is how you'd expect the migrations to work, so it's probably unnecessary to include. The old .stub method could be phased out, so maybe it shouldn't be mentioned in the docs to prevent future usage. Dunno :shrug: 