### PR TITLE
Use lang_path() when available

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -42,6 +42,14 @@ abstract class PackageServiceProvider extends ServiceProvider
     {
         $this->bootingPackage();
 
+        if ($this->package->hasTranslations) {
+            $langPath = 'vendor/' . $this->package->shortName();
+
+            $langPath = (function_exists('lang_path'))
+                ? lang_path($langPath)
+                : resource_path('lang/' . $langPath);
+        }
+
         if ($this->app->runningInConsole()) {
             foreach ($this->package->configFileNames as $configFileName) {
                 $this->publishes([
@@ -71,13 +79,8 @@ abstract class PackageServiceProvider extends ServiceProvider
             }
 
             if ($this->package->hasTranslations) {
-                // Laravel 8.64 and up uses lang_path().
-                $path = (version_compare(app()->version(), "8.64") >= 0)
-                    ? lang_path("vendor/{$this->package->shortName()}")
-                    : resource_path("lang/vendor/{$this->package->shortName()}");
-
                 $this->publishes([
-                    $this->package->basePath('/../resources/lang') => $path,
+                    $this->package->basePath('/../resources/lang') => $langPath,
                 ], "{$this->package->shortName()}-translations");
             }
 
@@ -99,7 +102,8 @@ abstract class PackageServiceProvider extends ServiceProvider
             );
 
             $this->loadJsonTranslationsFrom($this->package->basePath('/../resources/lang/'));
-            $this->loadJsonTranslationsFrom(resource_path('lang/vendor/'. $this->package->shortName()));
+
+            $this->loadJsonTranslationsFrom($langPath);
         }
 
         if ($this->package->hasViews) {

--- a/tests/PackageServiceProviderTests/PackageTranslationsTest.php
+++ b/tests/PackageServiceProviderTests/PackageTranslationsTest.php
@@ -26,8 +26,7 @@ class PackageTranslationsTest extends PackageServiceProviderTestCase
             ->artisan('vendor:publish --tag=package-tools-translations')
             ->assertExitCode(0);
 
-        // Laravel 8.64 and up uses lang_path().
-        $path = (version_compare(app()->version(), "8.64") >= 0)
+        $path = (function_exists('lang_path'))
             ? lang_path("vendor/package-tools/en/translations.php")
             : resource_path("lang/vendor/package-tools/en/translations.php");
         


### PR DESCRIPTION
Switched to using `lang_path()` when accessing `lang` folder.
Checking function availability rather then Laravel version.
Ref. https://github.com/spatie/laravel-package-tools/commit/9aa990a6466115e46238ee53f02063cd3eafa735