### PR TITLE
feat: custom view component path

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,15 @@ $package
 
 ### Working with Blade view components
 
-Any Blade view components that your package provides should be placed in the `<package root>/src/Components` directory.
+Any Blade view components that your package provides should be placed in the `<package root>/src/Components` directory. 
+
+If you want change the view component path, can use ``setViewComponentPath`` method
+
+```php
+$package
+    ->name('your-package-name')
+    ->setViewComponentPath('../Components')
+```
 
 You can register these views with the `hasViewComponents` command.
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -32,6 +32,8 @@ class Package
 
     public string $basePath;
 
+    public string $viewComponentPath;
+
     public function name(string $name): self
     {
         $this->name = $name;
@@ -178,6 +180,22 @@ class Package
     public function setBasePath(string $path): self
     {
         $this->basePath = $path;
+
+        return $this;
+    }
+
+    public function viewComponentPath(?string $viewComponentName = null): string
+    {
+        if ($viewComponentName === null) {
+            return $this->viewComponentPath;
+        }
+
+        return $this->viewComponentPath . DIRECTORY_SEPARATOR . ltrim($viewComponentName, DIRECTORY_SEPARATOR);
+    }
+
+    public function setViewComponentPath(string $path): self
+    {
+        $this->viewComponentPath = $path;
 
         return $this;
     }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -23,6 +23,8 @@ abstract class PackageServiceProvider extends ServiceProvider
 
         $this->package->setBasePath($this->getPackageBaseDir());
 
+        $this->package->setViewComponentPath($this->package->basePath('Components'));
+
         $this->configurePackage($this->package);
 
         if (empty($this->package->name)) {
@@ -116,7 +118,7 @@ abstract class PackageServiceProvider extends ServiceProvider
 
         if (count($this->package->viewComponents)) {
             $this->publishes([
-                $this->package->basePath('/../Components') => base_path("app/View/Components/vendor/{$this->package->shortName()}"),
+                $this->package->viewComponentPath() => base_path("app/View/Components/vendor/{$this->package->shortName()}"),
             ], "{$this->package->name}-components");
         }
 

--- a/tests/PackageServiceProviderTests/PackageCustomViewComponentPathTest.php
+++ b/tests/PackageServiceProviderTests/PackageCustomViewComponentPathTest.php
@@ -3,22 +3,23 @@
 namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
 
 use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\Tests\TestPackage\Src\Components\TestComponent;
+use Spatie\LaravelPackageTools\Tests\TestPackage\Components\PathTestComponent;
 
-class PackageViewComponentsTest extends PackageServiceProviderTestCase
+class PackageCustomViewComponentPathTest extends PackageServiceProviderTestCase
 {
     public function configurePackage(Package $package)
     {
         $package
             ->name('laravel-package-tools')
             ->hasViews()
-            ->hasViewComponent('abc', TestComponent::class);
+            ->setViewComponentPath($package->basePath('../Components'))
+            ->hasViewComponent('abc', PathTestComponent::class);
     }
 
     /** @test */
     public function it_can_load_the_view_components()
     {
-        $content = view('package-tools::component-test')->render();
+        $content = view('package-tools::component-path-test')->render();
 
         $this->assertStringStartsWith('<div>hello world</div>', $content);
     }
@@ -30,6 +31,6 @@ class PackageViewComponentsTest extends PackageServiceProviderTestCase
             ->artisan('vendor:publish --tag=laravel-package-tools-components')
             ->assertExitCode(0);
 
-        $this->assertFileExists(base_path('app/View/Components/vendor/package-tools/TestComponent.php'));
+        $this->assertFileExists(base_path('app/View/Components/vendor/package-tools/PathTestComponent.php'));
     }
 }

--- a/tests/TestPackage/Components/PathTestComponent.php
+++ b/tests/TestPackage/Components/PathTestComponent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\TestPackage\Components;
+
+use Illuminate\View\Component;
+
+class PathTestComponent extends Component
+{
+    public $message;
+
+    /**
+     * Create the component instance.
+     *
+     * @param  string  $message
+     * @return void
+     */
+    public function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return '<div>' . $this->message . '</div>';
+    }
+}

--- a/tests/TestPackage/Src/Components/TestComponent.php
+++ b/tests/TestPackage/Src/Components/TestComponent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\LaravelPackageTools\Tests\TestPackage\Components;
+namespace Spatie\LaravelPackageTools\Tests\TestPackage\Src\Components;
 
 use Illuminate\View\Component;
 

--- a/tests/TestPackage/resources/views/component-path-test.blade.php
+++ b/tests/TestPackage/resources/views/component-path-test.blade.php
@@ -1,0 +1,1 @@
+<x-abc-path-test-component message="hello world"/>


### PR DESCRIPTION
Fixed 'Can't locate path' error while publish view components.
Default path changed to ``package/src/Components/``.
Added ``setViewComponentPath`` method.
Added test for custom component path. So for ``setViewComponentPath`` method.