### PR TITLE
Allow running of migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ php artisan vendor:publish --tag=your-package-name-migrations
 
 Like you might expect, published migration files will be prefixed with the current datetime.
 
+You can also enable the migrations to be registered without needing the users of your package to publish them:
+
+```php
+$package
+    ->name('your-package-name')
+    ->hasMigrations(['my_package_tables', 'some_other_migration'])
+    ->runsMigrations();
+```
+
 ### Registering commands
 
 You can register any command you package provides with the `hasCommand` function.

--- a/src/Package.php
+++ b/src/Package.php
@@ -18,6 +18,8 @@ class Package
 
     public bool $hasAssets = false;
 
+    public bool $runsMigrations = false;
+
     public array $migrationFileNames = [];
 
     public array $routeFileNames = [];
@@ -112,6 +114,13 @@ class Package
     public function hasAssets(): self
     {
         $this->hasAssets = true;
+
+        return $this;
+    }
+
+    public function runsMigrations(bool $runsMigrations = true): self
+    {
+        $this->runsMigrations = $runsMigrations;
 
         return $this;
     }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -76,6 +76,10 @@ abstract class PackageServiceProvider extends ServiceProvider
                         $migrationFileName,
                         $now->addSecond()
                     ), ], "{$this->package->shortName()}-migrations");
+
+                if ($this->package->runsMigrations) {
+                    $this->loadMigrationsFrom($filePath);
+                }
             }
 
             if ($this->package->hasTranslations) {

--- a/tests/PackageServiceProviderTests/PackageMigrationTest.php
+++ b/tests/PackageServiceProviderTests/PackageMigrationTest.php
@@ -14,7 +14,8 @@ class PackageMigrationTest extends PackageServiceProviderTestCase
         $package
             ->name('laravel-package-tools')
             ->hasMigration('create_another_laravel_package_tools_table')
-            ->hasMigration('create_regular_laravel_package_tools_table');
+            ->hasMigration('create_regular_laravel_package_tools_table')
+            ->runsMigrations();
     }
 
     /** @test */
@@ -78,5 +79,15 @@ class PackageMigrationTest extends PackageServiceProviderTestCase
             $filePath,
             file_get_contents(__DIR__.'/../TestPackage/database/migrations/create_another_laravel_package_tools_table.php.stub')
         );
+    }
+
+    /** @test * */
+    public function it_can_run_migrations_which_registers_them()
+    {
+        /** @var \Illuminate\Database\Migrations\Migrator $migrator */
+        $migrator = app('migrator');
+
+        $this->assertCount(2, $migrator->paths());
+        $this->assertStringContainsString('laravel_package_tools', $migrator->paths()[0]);
     }
 }


### PR DESCRIPTION
This PR adds functionality similar to what [Cashier](https://github.com/laravel/cashier-stripe) does with its migrations to have them registered and run automatically. You can call the following on the package configuration:

```php
$package
    ->name('my-package')
    ->hasMigration('create_my_package_table')
    ->runsMigrations();
```

To enable automatically running the migrations without needing people to publish them.

It's also possible to add a check like Cashier does:

```php
// MyPackageServiceProvider
$package
    ->name('my-package')
    ->hasMigration('create_my_package_table')
    ->runsMigrations(MyPackage::$runsMigrations);
```

Which allows people to disable the automatic running and publish the migrations instead and add their own additions to them if you add support for this in your package.