### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -149,7 +149,7 @@ abstract class PackageServiceProvider extends ServiceProvider
             $migrationFileName = Str::of($migrationFileName)->afterLast('/');
         }
 
-        foreach (glob(database_path("${migrationsPath}*.php")) as $filename) {
+        foreach (glob(database_path("{$migrationsPath}*.php")) as $filename) {
             if ((substr($filename, -$len) === $migrationFileName . '.php')) {
                 return $filename;
             }


### PR DESCRIPTION
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes the only such occurrence in `spatie/laravel-package-tools` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)