### PR TITLE
feat: make install command hidden

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -9,6 +9,8 @@ use Spatie\LaravelPackageTools\Package;
 
 class InstallCommand extends Command
 {
+    protected $hidden = true;
+
     protected Package $package;
 
     public ?Closure $startWith = null;


### PR DESCRIPTION
As [suggested in the original PR](https://github.com/spatie/laravel-package-tools/pull/64#issuecomment-1238696219), this PR simply makes the install command hidden.