### PR TITLE
Fix for publishing view files that has its custom namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ command:
 php artisan vendor:publish --tag=your-package-name-views
 ```
 
+> **Note:**
+> 
+> If you use custom view namespace then you should change your publish command like this:
+```bash
+php artisan vendor:publish --tag=custom-view-namespace-views
+```
+
+
 ### Sharing global data with views
 
 You can share data with all views using the `sharesDataWithAllViews` method. This will make the shared variable

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -63,9 +63,16 @@ abstract class PackageServiceProvider extends ServiceProvider
             }
 
             if ($this->package->hasViews) {
-                $this->publishes([
-                    $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->shortName()}"),
-                ], "{$this->package->shortName()}-views");
+                if ($this->package->viewNamespace) {
+                    $this->publishes([
+                        $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->viewNamespace}"),
+                    ], "{$this->package->viewNamespace}-views");
+                } else {
+                    $this->publishes([
+                        $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->shortName()}"),
+                    ], "{$this->package->shortName()}-views");
+                }
+
             }
 
             $now = Carbon::now();

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -63,16 +63,9 @@ abstract class PackageServiceProvider extends ServiceProvider
             }
 
             if ($this->package->hasViews) {
-                if ($this->package->viewNamespace) {
-                    $this->publishes([
-                        $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->viewNamespace}"),
-                    ], "{$this->package->viewNamespace}-views");
-                } else {
-                    $this->publishes([
-                        $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->shortName()}"),
-                    ], "{$this->package->shortName()}-views");
-                }
-
+                $this->publishes([
+                    $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->packageView($this->package->viewNamespace)}"),
+                ], "{$this->packageView($this->package->viewNamespace)}-views");
             }
 
             $now = Carbon::now();
@@ -201,5 +194,10 @@ abstract class PackageServiceProvider extends ServiceProvider
         $reflector = new ReflectionClass(get_class($this));
 
         return dirname($reflector->getFileName());
+    }
+
+    public function packageView(?string $namespace)
+    {
+        return is_null($namespace) ? $this->package->shortName() : $this->package->viewNamespace;
     }
 }

--- a/tests/PackageServiceProviderTests/PackageViewsWithCustomNamespaceTest.php
+++ b/tests/PackageServiceProviderTests/PackageViewsWithCustomNamespaceTest.php
@@ -25,9 +25,9 @@ class PackageViewsWithCustomNamespaceTest extends PackageServiceProviderTestCase
     public function it_can_publish_the_views_with_a_custom_namespace()
     {
         $this
-            ->artisan('vendor:publish --tag=package-tools-views')
+            ->artisan('vendor:publish --tag=custom-namespace-views')
             ->assertExitCode(0);
 
-        $this->assertFileExists(base_path('resources/views/vendor/package-tools/test.blade.php'));
+        $this->assertFileExists(base_path('resources/views/vendor/custom-namespace/test.blade.php'));
     }
 }


### PR DESCRIPTION
When your package view uses custom namespace, published view ignores the namespace and keeps using its package name for vendor-view's directory name.

For example, imagine you create a package that has some sort of image gallery. And you choose 'laravel-images' for your package view's namespace.

Now someone downloaded your package then decided to customize the views. So the person ran `php artisan vendor:publish` command to publish the views from this package.

But [according to this sources](https://github.com/spatie/laravel-package-tools/blob/11cdf05a5d747778fad2c098e86cd48d20917e37/src/PackageServiceProvider.php#L65-L69) `laravel-package-tools` uses package name for its base_path and namespace and ignoring actual view namespace which the package creator specified.

So no matter how the user modifies the published views, Laravel couldn't find the published view files.

This PR provides a fix for this problem.