### PR TITLE
View Components publish has a bug

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -125,7 +125,7 @@ abstract class PackageServiceProvider extends ServiceProvider
 
         if (count($this->package->viewComponents)) {
             $this->publishes([
-                $this->package->basePath('/../Components') => base_path("app/View/Components/vendor/{$this->package->shortName()}"),
+                $this->package->basePath('/Components') => base_path("app/View/Components/vendor/{$this->package->shortName()}"),
             ], "{$this->package->name}-components");
         }
 

--- a/tests/PackageServiceProviderTests/PackageViewComponentsTest.php
+++ b/tests/PackageServiceProviderTests/PackageViewComponentsTest.php
@@ -3,7 +3,7 @@
 namespace Spatie\LaravelPackageTools\Tests\PackageServiceProviderTests;
 
 use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\Tests\TestPackage\Components\TestComponent;
+use Spatie\LaravelPackageTools\Tests\TestPackage\Src\Components\TestComponent;
 
 class PackageViewComponentsTest extends PackageServiceProviderTestCase
 {

--- a/tests/TestPackage/Src/Components/TestComponent.php
+++ b/tests/TestPackage/Src/Components/TestComponent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\LaravelPackageTools\Tests\TestPackage\Components;
+namespace Spatie\LaravelPackageTools\Tests\TestPackage\Src\Components;
 
 use Illuminate\View\Component;
 


### PR DESCRIPTION
1. Created `Alert.php` in `packagename/src/Components` directory.
2. Run vendor publish from project 
3. Receive following error

```
 ERROR  Can't locate path: </mnt/Work/www/packages/packagename/src/../Components>.  
```

Current workaround is to move the Components directory out of src. `packagename/Components` this work.

Checked the source and notice the following

```php
        if (count($this->package->viewComponents)) {
            $this->publishes([
                $this->package->basePath('/../Components') => base_path("app/View/Components/vendor/{$this->package->shortName()}"),
            ], "{$this->package->name}-components");
        }
```
Updating the Components path in above by removing `../` should fix this issue.