### PR TITLE
Removal of publishable service provider typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ When your package is installed into an app, running this command...
 php artisan vendor:publish --tag=your-package-name-provider
 ```
 
-... will copy `/resources/stubs/{$nameOfYourServiceProvider}.php` in your package
+... will copy `/resources/stubs/{$nameOfYourServiceProvider}.php.stub` in your package
 to `app/Providers/{$nameOfYourServiceProvider}.php` in the app of the user.
 
 ### Registering commands


### PR DESCRIPTION
Clears up a line about the publishing of the service provider. On line 351 is say it'll use `/resources/stubs/{$nameOfYourServiceProvider}.php.stub` but on line 359 it says `/resources/stubs/{$nameOfYourServiceProvider}.php`.

I've updated line 359 to use `/resources/stubs/{$nameOfYourServiceProvider}.php.stub` which is the correct value for the file the package tools will actually use.