### PR TITLE
Let Laravel discover migrations, using its default mechanism

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -21,6 +21,8 @@ class Package
 
     public bool $runsMigrations = false;
 
+    public bool $guessesMigrations = false;
+
     public array $migrationFileNames = [];
 
     public array $routeFileNames = [];
@@ -148,6 +150,7 @@ class Package
 
     public function hasMigration(string $migrationFileName): static
     {
+        $this->guessesMigrations = false;
         $this->migrationFileNames[] = $migrationFileName;
 
         return $this;
@@ -155,6 +158,7 @@ class Package
 
     public function hasMigrations(...$migrationFileNames): static
     {
+        $this->guessesMigrations = empty($migrationFileNames);
         $this->migrationFileNames = array_merge(
             $this->migrationFileNames,
             collect($migrationFileNames)->flatten()->toArray()

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -87,6 +87,16 @@ abstract class PackageServiceProvider extends ServiceProvider
                 }
             }
 
+            if ($this->package->guessesMigrations) {
+                $path = $this->package->basePath('/../database/migrations');
+
+                $this->publishes([$path => database_path('migrations')], "{$this->package->shortName()}-migrations");
+
+                if ($this->package->runsMigrations) {
+                    $this->loadMigrationsFrom($path);
+                }
+            }
+
             if ($this->package->hasTranslations) {
                 $this->publishes([
                     $this->package->basePath('/../resources/lang') => $langPath,

--- a/tests/PackageServiceProviderTests/GuessingMigrationTest.php
+++ b/tests/PackageServiceProviderTests/GuessingMigrationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Spatie\LaravelPackageTools\Package;
+use function Spatie\PestPluginTestTime\testTime;
+
+trait ConfigureGuessingPackageMigrationTest
+{
+    public function configurePackage(Package $package)
+    {
+        testTime()->freeze('2020-01-01 00:00:00');
+
+        $package
+            ->name('laravel-package-tools')
+            ->hasMigrations()
+            ->runsMigrations();
+    }
+}
+
+uses(ConfigureGuessingPackageMigrationTest::class);
+
+
+it('can guess and publish multiple migrations', function () {
+    $this
+        ->artisan('vendor:publish --tag=package-tools-migrations')
+        ->assertExitCode(0);
+    assertMigrationPublished('migrations/create_regular_laravel_package_tools_table.php');
+});
+
+it('can publish the migration without being stubbed', function () {
+    $this
+        ->artisan('vendor:publish --tag=package-tools-migrations')
+        ->assertExitCode(0);
+
+    assertMigrationPublished('create_regular_laravel_package_tools_table.php');
+});
+
+it('does not overwrite the existing migration', function () {
+    $this
+        ->artisan('vendor:publish --tag=package-tools-migrations')
+        ->assertExitCode(0);
+
+    assertMigrationPublished('create_regular_laravel_package_tools_table.php');
+
+    $filePath = database_path('migrations/create_regular_laravel_package_tools_table.php');
+
+    file_put_contents($filePath, 'modified');
+
+    $this
+        ->artisan('vendor:publish --tag=package-tools-migrations')
+        ->assertExitCode(0);
+
+    $this->assertStringEqualsFile($filePath, 'modified');
+});
+
+it('does overwrite the existing migration with force', function () {
+    $this
+        ->artisan('vendor:publish --tag=package-tools-migrations')
+        ->assertExitCode(0);
+
+    $filePath = database_path('migrations/create_regular_laravel_package_tools_table.php');
+
+    $this->assertFileExists($filePath);
+
+    file_put_contents($filePath, 'modified');
+
+    $this
+        ->artisan('vendor:publish --tag=package-tools-migrations  --force')
+        ->assertExitCode(0);
+
+    $this->assertStringEqualsFile(
+        $filePath,
+        file_get_contents(__DIR__.'/../TestPackage/database/migrations/create_regular_laravel_package_tools_table.php')
+    );
+});


### PR DESCRIPTION
As finely already exists, we can register our migrations, handwriting all files, one by one.
However, for some packages it is helpful, just to include all migrations at once, using the default Laravel way.

This PR adds this functionality, without any extra handling (stubs, timestamps etc).

Note: we can use only one of the two ways (manual vs auto registering)


You may proceed with this as you see fit