### PR TITLE
Enable publishing assets from the install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ class YourPackageServiceProvider extends PackageServiceProvider
             ->hasInstallCommand(function(InstallCommand $command) {
                 $command
                     ->publishConfigFile()
+                    ->publishAssets()
                     ->publishMigrations()
                     ->copyAndRegisterServiceProviderInApp()
                     ->askToStarRepoOnGitHub();
@@ -407,6 +408,7 @@ class YourPackageServiceProvider extends PackageServiceProvider
             ->hasInstallCommand(function(InstallCommand $command) {
                 $command
                     ->publishConfigFile()
+                    ->publishAssets()
                     ->publishMigrations()
                     ->askToRunMigrations()
                     ->copyAndRegisterServiceProviderInApp()
@@ -425,6 +427,7 @@ php artisan your-package-name:install
 Using the code above, that command will:
 
 - publish the config file
+- publish the assets
 - publish the migrations
 - copy the `/resources/stubs/MyProviderName.php.stub` from your package to `app/Providers/MyServiceProviderName.php`, and also register that
   provider in `config/app.php`
@@ -448,6 +451,7 @@ public function configurePackage(Package $package): void
                     $command->info('Hello, and welcome to my great new package!')
                 })
                 ->publishConfigFile()
+                ->publishAssets()
                 ->publishMigrations()
                ->askToRunMigrations()
                 ->copyAndRegisterServiceProviderInApp()

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -15,6 +15,8 @@ class InstallCommand extends Command
 
     protected bool $shouldPublishConfigFile = false;
 
+    protected bool $shouldPublishAssets = false;
+
     protected bool $shouldPublishMigrations = false;
 
     protected bool $askToRunMigrations = false;
@@ -49,6 +51,14 @@ class InstallCommand extends Command
 
             $this->callSilently("vendor:publish", [
                 '--tag' => "{$this->package->shortName()}-config",
+            ]);
+        }
+        
+        if ($this->shouldPublishAssets) {
+            $this->comment('Publishing assets...');
+
+            $this->callSilently("vendor:publish", [
+                '--tag' => "{$this->package->shortName()}-assets",
             ]);
         }
 
@@ -100,6 +110,13 @@ class InstallCommand extends Command
     public function publishConfigFile(): self
     {
         $this->shouldPublishConfigFile = true;
+
+        return $this;
+    }
+    
+    public function publishAssets(): self
+    {
+        $this->shouldPublishAssets = true;
 
         return $this;
     }

--- a/tests/PackageServiceProviderTests/InstallCommandTests/AssetsTest.php
+++ b/tests/PackageServiceProviderTests/InstallCommandTests/AssetsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use function PHPUnit\Framework\assertDirectoryExists;
+use Spatie\LaravelPackageTools\Commands\InstallCommand;
+use Spatie\LaravelPackageTools\Package;
+use function Spatie\PestPluginTestTime\testTime;
+
+trait ConfigureAssetsTest
+{
+    public function configurePackage(Package $package)
+    {
+        testTime()->freeze('2020-01-01 00:00:00');
+
+        $package
+            ->name('laravel-package-tools')
+            ->hasAssets()
+            ->hasInstallCommand(function (InstallCommand $command) {
+                $command->publishAssets();
+            });
+    }
+}
+
+uses(ConfigureAssetsTest::class);
+
+it('can install the assets', function () {
+    $assetPath = public_path('/vendor/package-tools');
+
+    $this
+        ->artisan('package-tools:install')
+        ->assertSuccessful();
+
+    assertDirectoryExists($assetPath);
+});


### PR DESCRIPTION
This PR allows the publishing of assets from the install command, this brings the package more in line with plugins like Horizon or Nova.