### PR TITLE
Specify commands that will not be available on http calls

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -27,6 +27,8 @@ class Package
 
     public array $commands = [];
 
+    public array $consoleCommands = [];
+
     public array $viewComponents = [];
 
     public array $sharedViewData = [];
@@ -70,7 +72,7 @@ class Package
 
         $callable($installCommand);
 
-        $this->commands[] = $installCommand;
+        $this->consoleCommands[] = $installCommand;
 
         return $this;
     }
@@ -173,6 +175,20 @@ class Package
     public function hasCommands(...$commandClassNames): static
     {
         $this->commands = array_merge($this->commands, collect($commandClassNames)->flatten()->toArray());
+
+        return $this;
+    }
+
+    public function hasConsoleCommand(string $commandClassName): static
+    {
+        $this->consoleCommands[] = $commandClassName;
+
+        return $this;
+    }
+
+    public function hasConsoleCommands(...$commandClassNames): static
+    {
+        $this->consoleCommands = array_merge($this->consoleCommands, collect($commandClassNames)->flatten()->toArray());
 
         return $this;
     }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -104,6 +104,10 @@ abstract class PackageServiceProvider extends ServiceProvider
             $this->commands($this->package->commands);
         }
 
+        if (! empty($this->package->consoleCommands) && $this->app->runningInConsole()) {
+            $this->commands($this->package->consoleCommands);
+        }
+
         if ($this->package->hasTranslations) {
             $this->loadTranslationsFrom(
                 $this->package->basePath('/../resources/lang/'),


### PR DESCRIPTION
There are some commands that should not be able to be executed from the context of web application interfaces, like InstallCommand, NetworkCommand

This PR gives us the option to register commands that will exclusively be used from the console.

Also on laravel documentation there is an example https://laravel.com/docs/10.x/packages#commands (_runningInConsole_)

**Example:**
```php
$package
    ->name('your-package-name')
    ->hasConfigFile()
    // console context command
    ->hasConsoleCommand(ConsoleExclusiveCommand::class)
    // console/web context command
    ->hasCommand(GlobalCommand::class)
    // InstallCommand must be console context command
    ->hasInstallCommand(function(InstallCommand $command) {
        $command
            ->publishMigrations();
    })
```
This was broken here: #23