### PR TITLE
Lumen compatibility on publishing

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -55,7 +55,7 @@ abstract class PackageServiceProvider extends ServiceProvider
                 : resource_path('lang/' . $langPath);
         }
 
-        if ($this->app->runningInConsole()) {
+        if ($this->app->runningInConsole() && method_exists('config_path')) {
             foreach ($this->package->configFileNames as $configFileName) {
                 $this->publishes([
                     $this->package->basePath("/../config/{$configFileName}.php") => config_path("{$configFileName}.php"),


### PR DESCRIPTION
function `config_path` not available in **Lumen Framework**,  and 'publish' is not relevant there

https://github.com/spatie/laravel-package-tools/blob/d7ea4f74ffe1f7863f01bf5ba4b6d64847dacf8b/src/PackageServiceProvider.php#L61-L61
This part forces users to add a helper function to be able to use the package, with this change this would be optional, you don't need to add anything new to use it, you can keep it as simple as possible, but it leaves open the possibility of using packages like [larasupport](https://github.com/irazasyed/larasupport) to have the 'publish' option
