### PR TITLE
Fix install command on Laravel 10.x breaking change

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -184,8 +184,8 @@ class InstallCommand extends Command
         }
 
         file_put_contents(config_path('app.php'), str_replace(
-            "Illuminate\\View\ViewServiceProvider::class,",
-            "Illuminate\\View\ViewServiceProvider::class," . PHP_EOL . "        {$namespace}\Providers\\" . $providerName . "::class,",
+            "{$namespace}\\Providers\\BroadcastServiceProvider::class,",
+            "{$namespace}\\Providers\\BroadcastServiceProvider::class," . PHP_EOL . "        {$namespace}{$class},",
             $appConfig
         ));
 


### PR DESCRIPTION
> test are failing because Illuminate\View\ViewServiceProvider::class, was deleted on https://github.com/laravel/laravel/pull/6159 laravel 10, not related with this PR

Apparently you have to change the provider that is used as a reference for the replace
[laravel/config/app.php#L158-L171](https://github.com/laravel/laravel/blob/5070934fc5fb8bea7a4c8eca44a6b0bd59571be7/config/app.php#L158-L171)