### PR TITLE
add inertia components publish option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ $package
 
 Any views your package provides, should be placed in the `<package root>/resources/js/Pages` directory.
 
-You can register these views with the `hasInertiaComponents` command.
+You can register these components with the `hasInertiaComponents` command.
 
 ```php
 $package
@@ -228,10 +228,10 @@ $package
     ->hasInertiaComponents();
 ```
 
-This will register your views with Laravel.
+This will register your components with Laravel.
 
 If you have an inertia component `<package root>/resources/js/Pages/myComponent.vue`, you can use it like
-this: `Inertia::render('myComponent')`. Of course, you can also use subdirectories to organise your components.
+this: `Inertia::render('YourPackageName/myComponent')`. Of course, you can also use subdirectories to organise your components.
 
 #### Publishing inertia components
 
@@ -241,6 +241,8 @@ command:
 ```bash
 php artisan vendor:publish --tag=your-package-name-inertia-components
 ```
+
+And this command is available with your package [installer-command](#adding-an-installer-command)
 
 ### Working with translations
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ $package
 
 ### Working with inertia components
 
-Any views your package provides, should be placed in the `<package root>/resources/js/Pages` directory.
+Any `.vue` or `.jsx` files your package provides, should be placed in the `<package root>/resources/js/Pages` directory.
 
 You can register these components with the `hasInertiaComponents` command.
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,32 @@ $package
     });
 ```
 
+### Working with inertia components
+
+Any views your package provides, should be placed in the `<package root>/resources/js/Pages` directory.
+
+You can register these views with the `hasInertiaComponents` command.
+
+```php
+$package
+    ->name('your-package-name')
+    ->hasInertiaComponents();
+```
+
+This will register your views with Laravel.
+
+If you have an inertia component `<package root>/resources/js/Pages/myComponent.vue`, you can use it like
+this: `Inertia::render('myComponent')`. Of course, you can also use subdirectories to organise your components.
+
+#### Publishing inertia components
+
+Calling `hasInertiaComponents` will also make inertia components publishable. Users of your package will be able to publish the views with this
+command:
+
+```bash
+php artisan vendor:publish --tag=your-package-name-inertia-components
+```
+
 ### Working with translations
 
 Any translations your package provides, should be placed in the `<package root>/resources/lang/<language-code>`

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -17,6 +17,8 @@ class InstallCommand extends Command
 
     protected bool $shouldPublishAssets = false;
 
+    protected bool $shouldPublishInertiaComponents = false;
+
     protected bool $shouldPublishMigrations = false;
 
     protected bool $askToRunMigrations = false;
@@ -53,12 +55,20 @@ class InstallCommand extends Command
                 '--tag' => "{$this->package->shortName()}-config",
             ]);
         }
-        
+
         if ($this->shouldPublishAssets) {
             $this->comment('Publishing assets...');
 
             $this->callSilently("vendor:publish", [
                 '--tag' => "{$this->package->shortName()}-assets",
+            ]);
+        }
+
+        if ($this->shouldPublishInertiaComponents) {
+            $this->comment('Publishing inertia components...');
+
+            $this->callSilently("vendor:publish", [
+                '--tag' => "{$this->package->shortName()}-inertia-components",
             ]);
         }
 
@@ -113,10 +123,17 @@ class InstallCommand extends Command
 
         return $this;
     }
-    
+
     public function publishAssets(): self
     {
         $this->shouldPublishAssets = true;
+
+        return $this;
+    }
+
+    public function publishInertiaComponents(): self
+    {
+        $this->shouldPublishInertiaComponents = true;
 
         return $this;
     }

--- a/src/Package.php
+++ b/src/Package.php
@@ -13,6 +13,8 @@ class Package
 
     public bool $hasViews = false;
 
+    public bool $hasInertiaComponents = false;
+
     public ?string $viewNamespace = null;
 
     public bool $hasTranslations = false;
@@ -85,6 +87,15 @@ class Package
     public function hasViews(string $namespace = null): static
     {
         $this->hasViews = true;
+
+        $this->viewNamespace = $namespace;
+
+        return $this;
+    }
+
+    public function hasInertiaComponents(string $namespace = null): static
+    {
+        $this->hasInertiaComponents = true;
 
         $this->viewNamespace = $namespace;
 

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -68,6 +68,12 @@ abstract class PackageServiceProvider extends ServiceProvider
                 ], "{$this->packageView($this->package->viewNamespace)}-views");
             }
 
+            if ($this->package->hasInertiaComponents) {
+                $this->publishes([
+                    $this->package->basePath('/../resources/js/Pages') => base_path("resources/js/Pages/{$this->packageView($this->package->viewNamespace)}"),
+                ], "{$this->packageView($this->package->viewNamespace)}-inertia-components");
+            }
+
             $now = Carbon::now();
             foreach ($this->package->migrationFileNames as $migrationFileName) {
                 $filePath = $this->package->basePath("/../database/migrations/{$migrationFileName}.php");

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -69,8 +69,10 @@ abstract class PackageServiceProvider extends ServiceProvider
             }
 
             if ($this->package->hasInertiaComponents) {
+                $packageDirectoryName = Str::of($this->packageView($this->package->viewNamespace))->studly()->remove('-')->value();
+
                 $this->publishes([
-                    $this->package->basePath('/../resources/js/Pages') => base_path("resources/js/Pages/{$this->packageView($this->package->viewNamespace)}"),
+                    $this->package->basePath('/../resources/js/Pages') => base_path("resources/js/Pages/{$packageDirectoryName}"),
                 ], "{$this->packageView($this->package->viewNamespace)}-inertia-components");
             }
 


### PR DESCRIPTION
It should allow packages that has InertiaJS components to add them as publishable files with the install command:

```php
use Spatie\LaravelPackageTools\PackageServiceProvider;
use Spatie\LaravelPackageTools\Package;
use MyPackage\ViewComponents\Alert;
use Spatie\LaravelPackageTools\Commands\InstallCommand;

class YourPackageServiceProvider extends PackageServiceProvider
{
    public function configurePackage(Package $package): void
    {
        $package
            ->name('your-package-name')
            ->hasConfigFile()
            ->hasInertiaComponents()
            ->hasInstallCommand(function(InstallCommand $command) {
                $command
                    ->publishConfigFile()
                    ->publishAssets()
                    ->publishMigrations()
                    ->copyAndRegisterServiceProviderInApp()
                    ->askToStarRepoOnGitHub();
            });
    }
}
```