### PR TITLE
Enable publishing any tag name with the install command

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -88,9 +88,9 @@ class InstallCommand extends Command
         }
     }
 
-    public function publish(string $tag): self
+    public function publish(string ...$tag): self
     {
-        $this->publishes[] = $tag;
+        $this->publishes = array_merge($this->publishes, $tag);
 
         return $this;
     }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -13,13 +13,7 @@ class InstallCommand extends Command
 
     public ?Closure $startWith = null;
 
-    protected bool $shouldPublishConfigFile = false;
-
-    protected bool $shouldPublishAssets = false;
-
-    protected bool $shouldPublishInertiaComponents = false;
-
-    protected bool $shouldPublishMigrations = false;
+    protected array $publishes = [];
 
     protected bool $askToRunMigrations = false;
 
@@ -48,35 +42,12 @@ class InstallCommand extends Command
             ($this->startWith)($this);
         }
 
-        if ($this->shouldPublishConfigFile) {
-            $this->comment('Publishing config file...');
+        foreach ($this->publishes as $tag) {
+            $name = str_replace('-', ' ', $tag);
+            $this->comment("Publishing $name...");
 
             $this->callSilently("vendor:publish", [
-                '--tag' => "{$this->package->shortName()}-config",
-            ]);
-        }
-
-        if ($this->shouldPublishAssets) {
-            $this->comment('Publishing assets...');
-
-            $this->callSilently("vendor:publish", [
-                '--tag' => "{$this->package->shortName()}-assets",
-            ]);
-        }
-
-        if ($this->shouldPublishInertiaComponents) {
-            $this->comment('Publishing inertia components...');
-
-            $this->callSilently("vendor:publish", [
-                '--tag' => "{$this->package->shortName()}-inertia-components",
-            ]);
-        }
-
-        if ($this->shouldPublishMigrations) {
-            $this->comment('Publishing migration...');
-
-            $this->callSilently("vendor:publish", [
-                '--tag' => "{$this->package->shortName()}-migrations",
+                '--tag' => "{$this->package->shortName()}-{$tag}",
             ]);
         }
 
@@ -117,32 +88,31 @@ class InstallCommand extends Command
         }
     }
 
-    public function publishConfigFile(): self
+    public function publish(string $tag): self
     {
-        $this->shouldPublishConfigFile = true;
+        $this->publishes[] = $tag;
 
         return $this;
+    }
+
+    public function publishConfigFile(): self
+    {
+        return $this->publish('config');
     }
 
     public function publishAssets(): self
     {
-        $this->shouldPublishAssets = true;
-
-        return $this;
+        return $this->publish('assets');
     }
 
     public function publishInertiaComponents(): self
     {
-        $this->shouldPublishInertiaComponents = true;
-
-        return $this;
+        return $this->publish('inertia-components');
     }
 
     public function publishMigrations(): self
     {
-        $this->shouldPublishMigrations = true;
-
-        return $this;
+        return $this->publish('migrations');
     }
 
     public function askToRunMigrations(): self

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -44,7 +44,7 @@ class InstallCommand extends Command
 
         foreach ($this->publishes as $tag) {
             $name = str_replace('-', ' ', $tag);
-            $this->comment("Publishing $name...");
+            $this->comment("Publishing {$name}...");
 
             $this->callSilently("vendor:publish", [
                 '--tag' => "{$this->package->shortName()}-{$tag}",


### PR DESCRIPTION
This PR adds a new `->publish($tag)` method on the install command that enables you to publish arbitrary tag names. For instance, we might use `->publish('nova')` to publish Nova resources from our package.

This way, we don't need to add an individual method for each possible tag name. I've also replaced all the individual `$shouldPublish***` properties with the new `$publishes` array.

Let me know what you think. Thanks!!