### PR TITLE
Using the static to call the static method

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -85,10 +85,7 @@ abstract class PackageServiceProvider extends ServiceProvider
                 }
 
                 $this->publishes([
-                    $filePath => $this->generateMigrationName(
-                        $migrationFileName,
-                        $now->addSecond()
-                    ), ], "{$this->package->shortName()}-migrations");
+                    $filePath => static::generateMigrationName($migrationFileName, $now->addSecond()), ], "{$this->package->shortName()}-migrations");
 
                 if ($this->package->runsMigrations) {
                     $this->loadMigrationsFrom($filePath);


### PR DESCRIPTION
# Changed log

- It seems that the `generateMigrationName` is the static method and it should use the `static` call rather than using the `$this` call.