### PR TITLE
Make Package class conditionable

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -3,10 +3,13 @@
 namespace Spatie\LaravelPackageTools;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 
 class Package
 {
+    use Conditionable;
+
     public string $name;
 
     public array $configFileNames = [];


### PR DESCRIPTION
Hello Spatie Team!

This is my first PR for this package.
This PR adds the `Illuminate\Support\Traits\Conditionable` trait to the Package class.

This enhancement empowers package maintainers with the flexibility to tailor their package behavior dynamically. For instance, it enables conditional package configuration as demonstrated below:

```PHP
public function configurePackage(Package $package): void
{
    ...
    $package->when(config('package.enable_routes', false), fn(Package $package) => $package->hasRoute('package'));
}
```

I have not added any tests for this since it relies on a Laravel Core functionality, which is well-tested.

Thank you!