### PR TITLE
add stubs features

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,26 @@ php artisan vendor:publish --tag=your-package-name-assets
 This will copy over the assets to the `public/vendor/<your-package-name>` directory in the app where your package is
 installed in.
 
+### Working with stubs
+
+Any assets your package provides, should be placed in the `<package root>/stubs/` directory.
+
+You can make these stubs publishable using the `hasStubs` method.
+
+```php
+$package
+    ->name('your-package-name')
+    ->hasStubs();
+```
+
+Users of your package will be able to publish the stubs with this command:
+
+```bash
+php artisan vendor:publish --tag=your-package-name-stubs
+```
+
+Also, the stubs are available in a convenient way with your package [installer-command](#adding-an-installer-command)
+
 ### Working with migrations
 
 The `PackageServiceProvider` assumes that any migrations are placed in this
@@ -433,11 +453,13 @@ class YourPackageServiceProvider extends PackageServiceProvider
         $package
             ->name('your-package-name')
             ->hasConfigFile()
+            ->hasStubs()
             ->hasMigration('create_package_tables')
             ->publishesServiceProvider('MyServiceProviderName')
             ->hasInstallCommand(function(InstallCommand $command) {
                 $command
                     ->publishConfigFile()
+                    ->publishStubs()
                     ->publishAssets()
                     ->publishMigrations()
                     ->askToRunMigrations()

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -105,6 +105,11 @@ class InstallCommand extends Command
         return $this->publish('assets');
     }
 
+    public function publishStubs(): self
+    {
+        return $this->publish('stubs');
+    }
+
     public function publishInertiaComponents(): self
     {
         return $this->publish('inertia-components');

--- a/src/Package.php
+++ b/src/Package.php
@@ -21,6 +21,10 @@ class Package
 
     public bool $hasAssets = false;
 
+    public bool $hasStubs = false;
+
+    public bool $stubsWrapper = false;
+
     public bool $runsMigrations = false;
 
     public array $migrationFileNames = [];
@@ -148,6 +152,15 @@ class Package
     public function hasAssets(): static
     {
         $this->hasAssets = true;
+
+        return $this;
+    }
+
+    public function hasStubs($stubsWrapper = true): static
+    {
+        $this->hasStubs = true;
+
+        $this->stubsWrapper = $stubsWrapper;
 
         return $this;
     }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -106,6 +106,15 @@ abstract class PackageServiceProvider extends ServiceProvider
                     $this->package->basePath('/../resources/dist') => public_path("vendor/{$this->package->shortName()}"),
                 ], "{$this->package->shortName()}-assets");
             }
+
+            if ($this->package->hasStubs) {
+
+                $destination = $this->package->stubsWrapper ? "stubs/{$this->package->shortName()}" : 'stubs';
+
+                $this->publishes([
+                    $this->package->basePath('/../stubs') => base_path($destination),
+                ], "{$this->package->shortName()}-stubs");
+            }
         }
 
         if (! empty($this->package->commands)) {

--- a/tests/PackageServiceProviderTests/InstallCommandTests/StubsTest.php
+++ b/tests/PackageServiceProviderTests/InstallCommandTests/StubsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use function PHPUnit\Framework\assertFileExists;
+use Spatie\LaravelPackageTools\Commands\InstallCommand;
+use Spatie\LaravelPackageTools\Package;
+use function Spatie\PestPluginTestTime\testTime;
+
+trait ConfigureStubsFileTest
+{
+    public function configurePackage(Package $package)
+    {
+        testTime()->freeze('2020-01-01 00:00:00');
+
+        $package
+            ->name('laravel-package-tools')
+            ->hasStubs()
+            ->hasInstallCommand(function (InstallCommand $command) {
+                $command->publishStubs();
+            });
+    }
+}
+
+uses(ConfigureStubsFileTest::class);
+
+it('can install the stub files', function () {
+    $this
+        ->artisan('package-tools:install')
+        ->assertSuccessful();
+
+    assertFileExists(base_path('stubs/package-tools/dummy.stub'));
+});

--- a/tests/PackageServiceProviderTests/InstallCommandTests/StubsWithoutWrapperTest.php
+++ b/tests/PackageServiceProviderTests/InstallCommandTests/StubsWithoutWrapperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use function PHPUnit\Framework\assertFileExists;
+use Spatie\LaravelPackageTools\Commands\InstallCommand;
+use Spatie\LaravelPackageTools\Package;
+use function Spatie\PestPluginTestTime\testTime;
+
+trait ConfigureStubsWithoutPackageNameWrapperFileTest
+{
+    public function configurePackage(Package $package)
+    {
+        testTime()->freeze('2020-01-01 00:00:00');
+
+        $package
+            ->name('laravel-package-tools')
+            ->hasStubs(false)
+            ->hasInstallCommand(function (InstallCommand $command) {
+                $command->publishStubs();
+            });
+    }
+}
+
+uses(ConfigureStubsWithoutPackageNameWrapperFileTest::class);
+
+it('can install the stub files without package name wrapper', function () {
+    $this
+        ->artisan('package-tools:install')
+        ->assertSuccessful();
+
+    assertFileExists(base_path('stubs/dummy.stub'));
+});

--- a/tests/PackageServiceProviderTests/PackageStubsTest.php
+++ b/tests/PackageServiceProviderTests/PackageStubsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertFileExists;
+use Spatie\LaravelPackageTools\Package;
+
+trait ConfigurePackageStubsTest
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools')
+            ->hasConfigFile();
+    }
+}
+
+uses(ConfigurePackageStubsTest::class);
+
+it('can publish the stub files', function () {
+    $this
+        ->artisan('vendor:publish --tag=package-tools-stubs')
+        ->assertExitCode(0);
+
+    assertFileExists(base_path('stubs/package-tools/dummy.stub'));
+});

--- a/tests/TestPackage/stubs/dummy.stub
+++ b/tests/TestPackage/stubs/dummy.stub
@@ -1,0 +1,6 @@
+<?php
+
+class DummyClass
+{
+
+}


### PR DESCRIPTION
# What makes this PR

it adds a `hasStubs()` & `publishStubs()` methods to make easier to configure a package.

```php
$package
    ->name('your-package-name')
    ->hasStubs()
    ->hasInstallCommand(function(InstallCommand $command) {
        $command
            ->publishStubs()
});
```

it also adds a `packageNameWrapper` param to allow stubs to be published in different ways:

Eg: my package has a stub in `stubs/dummy.stub`, it can be stored in:

- `stubs/my-package/dummy.stub`
- `stubs/dummy.stub`

## Demo

https://www.loom.com/share/60e34713e28941e0a0037790a037b6af?sid=4f202a92-a51e-489f-add3-7162f1780713