### PR TITLE
handle relative path in migration file exists check

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -167,7 +167,8 @@ abstract class PackageServiceProvider extends ServiceProvider
 
     public static function generateMigrationName(string $migrationFileName, Carbon $now): string
     {
-        $migrationsPath = 'migrations/';
+        $migrationsPath = 'migrations/' . dirname($migrationFileName) . '/';
+        $migrationFileName = basename($migrationFileName);
 
         $len = strlen($migrationFileName) + 4;
 


### PR DESCRIPTION
Hey there,

I'm using your laravel settings package for my own ones. Therefore I have a settings migration file in ```database/settings```.

Now I try to publish these settings like this:

```php
->hasMigrations([
    '../settings/create_mail_settings'
])
```

First publish works without a problem. But if I run it again it copies the file again because only the migrations path is checked for the file. So I changed the code to resolve the path using the given publish file.