### PR TITLE
Feat multiple providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,17 @@ php artisan vendor:publish --tag=your-package-name-provider
 ... will copy `/resources/stubs/{$nameOfYourServiceProvider}.php.stub` in your package
 to `app/Providers/{$nameOfYourServiceProvider}.php` in the app of the user.
 
+You can publish multiple providers at cone by declaring an array of providers name
+```php
+$package
+    ->name('your-package-name')
+    ->publishesServiceProvider([
+        $nameOfYourServiceProvider1,
+        $nameOfYourServiceProvider2,
+        ...
+    ]);
+```
+
 ### Registering commands
 
 You can register any command you package provides with the `hasCommand` function.

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -62,7 +62,7 @@ class InstallCommand extends Command
         if ($this->copyServiceProviderInApp) {
             $this->comment('Publishing service provider...');
 
-            $this->copyServiceProviderInApp();
+            $this->copyServiceProvidersInApp();
         }
 
         if ($this->starRepo) {
@@ -150,9 +150,28 @@ class InstallCommand extends Command
         return $this;
     }
 
-    protected function copyServiceProviderInApp(): self
+    protected function copyServiceProvidersInApp(): self
     {
-        $providerName = $this->package->publishableProviderName;
+        $providersName = $this->package->publishableProviderName;
+
+        if (! $providersName) {
+            return $this;
+        }
+
+        if (is_array($providersName)) {
+            foreach($providersName as $providerName) {
+                $this->copyServiceProviderInApp($providerName);
+            }
+        } else {
+            $this->copyServiceProviderInApp($providersName);
+        }
+
+        return $this;
+    }
+
+    protected function copyServiceProviderInApp(?string $providerName = null): self
+    {
+        $providerName = $providerName ?? $this->package->publishableProviderName;
 
         if (! $providerName) {
             return $this;

--- a/src/Package.php
+++ b/src/Package.php
@@ -39,7 +39,7 @@ class Package
 
     public string $basePath;
 
-    public ?string $publishableProviderName = null;
+    public mixed $publishableProviderName = null;
 
     public function name(string $name): static
     {
@@ -61,7 +61,7 @@ class Package
         return $this;
     }
 
-    public function publishesServiceProvider(string $providerName): static
+    public function publishesServiceProvider(mixed $providerName): static
     {
         $this->publishableProviderName = $providerName;
 

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -147,9 +147,17 @@ abstract class PackageServiceProvider extends ServiceProvider
                 $providersName = [$providersName];
             }
 
-            $this->publishes(Arr::mapWithKeys($providersName, function ($publishableProviderName, $key) {
-                return [$this->package->basePath("/../resources/stubs/{$publishableProviderName}.php.stub") => base_path("app/Providers/{$publishableProviderName}.php")];
-            }), "{$this->package->shortName()}-provider");
+            $providers = [];
+
+            foreach ($providersName as $key => $publishableProviderName) {
+                $assoc = [$this->package->basePath("/../resources/stubs/{$publishableProviderName}.php.stub") => base_path("app/Providers/{$publishableProviderName}.php")];
+    
+                foreach ($assoc as $mapKey => $mapValue) {
+                    $providers[$mapKey] = $mapValue;
+                }
+            }
+            
+            $this->publishes($providers, "{$this->package->shortName()}-provider");
         }
 
 

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -149,12 +149,8 @@ abstract class PackageServiceProvider extends ServiceProvider
 
             $providers = [];
 
-            foreach ($providersName as $key => $publishableProviderName) {
-                $assoc = [$this->package->basePath("/../resources/stubs/{$publishableProviderName}.php.stub") => base_path("app/Providers/{$publishableProviderName}.php")];
-    
-                foreach ($assoc as $mapKey => $mapValue) {
-                    $providers[$mapKey] = $mapValue;
-                }
+            foreach ($providersName as $publishableProviderName) {
+                $providers[$this->package->basePath("/../resources/stubs/{$publishableProviderName}.php.stub")] = base_path("app/Providers/{$publishableProviderName}.php");
             }
             
             $this->publishes($providers, "{$this->package->shortName()}-provider");

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelPackageTools;
 
 use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -141,10 +142,14 @@ abstract class PackageServiceProvider extends ServiceProvider
             ], "{$this->package->name}-components");
         }
 
-        if ($this->package->publishableProviderName) {
-            $this->publishes([
-                $this->package->basePath("/../resources/stubs/{$this->package->publishableProviderName}.php.stub") => base_path("app/Providers/{$this->package->publishableProviderName}.php"),
-            ], "{$this->package->shortName()}-provider");
+        if ($providersName = $this->package->publishableProviderName) {
+            if (!is_array($providersName)) {
+                $providersName = [$providersName];
+            }
+
+            $this->publishes(Arr::mapWithKeys($providersName, function ($publishableProviderName, $key) {
+                return [$this->package->basePath("/../resources/stubs/{$publishableProviderName}.php.stub") => base_path("app/Providers/{$publishableProviderName}.php")];
+            }), "{$this->package->shortName()}-provider");
         }
 
 

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -147,13 +147,13 @@ abstract class PackageServiceProvider extends ServiceProvider
                 $providersName = [$providersName];
             }
 
-            $providers = [];
+            $publishableProviders = [];
 
             foreach ($providersName as $publishableProviderName) {
-                $providers[$this->package->basePath("/../resources/stubs/{$publishableProviderName}.php.stub")] = base_path("app/Providers/{$publishableProviderName}.php");
+                $publishableProviders[$this->package->basePath("/../resources/stubs/{$publishableProviderName}.php.stub")] = base_path("app/Providers/{$publishableProviderName}.php");
             }
             
-            $this->publishes($providers, "{$this->package->shortName()}-provider");
+            $this->publishes($publishableProviders, "{$this->package->shortName()}-provider");
         }
 
 


### PR DESCRIPTION
This PR adds the possibility to declare multiple publishable providers. It's useful when the package need to publish and register multiple providers (like a standard ServiceProvider + an AuthServiceProvider).

It can be used with the already existing method `publishesServiceProvider` but by providing and array of providers name

```php
$package
    ->name('your-package-name')
    ->publishesServiceProvider([
        $nameOfYourServiceProvider1,
        $nameOfYourServiceProvider2,
        ...
    ]);
```