### PR TITLE
feat: Allow finding the base path when a laravel folder organisation …

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -205,8 +205,16 @@ abstract class PackageServiceProvider extends ServiceProvider
     protected function getPackageBaseDir(): string
     {
         $reflector = new ReflectionClass(get_class($this));
+        $packageBaseDir = dirname($reflector->getFileName());
 
-        return dirname($reflector->getFileName());
+        // Some packages like to keep Laravels directory structure and place
+        // the service providers in a Providers folder.
+        // move up a level when this is the case.
+        if (str_ends_with($packageBaseDir, DIRECTORY_SEPARATOR.'Providers')) {
+            $packageBaseDir = dirname($packageBaseDir);
+        }
+
+        return $packageBaseDir;
     }
 
     public function packageView(?string $namespace)

--- a/tests/PackageServiceProviderTests/PackageBasePathTest.php
+++ b/tests/PackageServiceProviderTests/PackageBasePathTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\Tests\TestPackage\Src\Providers\ServiceProvider;
+
+trait ConfigurePackageBasePathTest
+{
+    public function configurePackage(Package $package)
+    {
+        $package
+            ->name('laravel-package-tools');
+    }
+}
+
+uses(ConfigurePackageBasePathTest::class);
+
+it('will set the base path to the Src dir when the laravel folder organisation is applied', function () {
+    $provider = new ServiceProvider(app());
+    expect($provider->getPackageBaseDir())->toEndWith( DIRECTORY_SEPARATOR.'TestPackage'.DIRECTORY_SEPARATOR.'Src');
+});

--- a/tests/TestPackage/Src/Providers/ServiceProvider.php
+++ b/tests/TestPackage/Src/Providers/ServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\LaravelPackageTools\Tests\TestPackage\Src\Providers;
+
+use Closure;
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+
+class ServiceProvider extends PackageServiceProvider
+{
+    public function getPackageBaseDir():string
+    {
+        return parent::getPackageBaseDir();
+    }
+
+    public function configurePackage(Package $package): void
+    {
+        $package->name('laravel-package-tools');
+    }
+}


### PR DESCRIPTION
Hi,

Thank you for providing and maintaining so much quality code. I ran across something when I updated some of our internal packages to use the laravel-package-tools. Some of them follow Laravels app folder structure, i.e. they have the provider in a Providers folder. The package tools assume the provider lives in the src root and automatically sets the Providers folder as the base path. This results in pretty much everything not being found (out of the box) and requires each package to call `setBasePath`. 

This PR adds a check in `getPackageBaseDir()` to see whether the path found ends in `/Providers` and if so, takes its parent folder as the base path. As I have seen the structuring of a package like Laravels app folder in other project too, I thought this PR might be useful to others too. Curious to learn what you think!