### PR TITLE
Support Laravel 11 development

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,16 +10,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1, 8.2]
-        laravel: [10.*, 9.*]
+        laravel: [11.*, 10.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
         exclude:
           - laravel: 10.*
             php: 8.0
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -41,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:^2.64.1" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:^2.72.2" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^7.7|^8.0",
-        "pestphp/pest": "^1.22",
-        "phpunit/phpunit": "^9.5.24",
-        "spatie/pest-plugin-test-time": "^1.1"
+        "orchestra/testbench": "^7.7|^8.0|^9.0",
+        "pestphp/pest": "^1.22|^2",
+        "phpunit/phpunit": "^9.5.24|^10.5",
+        "spatie/pest-plugin-test-time": "^1.1|^2.2"
     },
     "autoload": {
         "psr-4": {

--- a/tests/PackageServiceProviderTests/InstallCommandTests/CopyAndRegisterServiceProviderInAppTest.php
+++ b/tests/PackageServiceProviderTests/InstallCommandTests/CopyAndRegisterServiceProviderInAppTest.php
@@ -3,6 +3,7 @@
 use function PHPUnit\Framework\assertStringContainsString;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
+use function PHPUnit\Framework\assertStringNotContainsString;
 
 trait ConfigureCopyAndRegisterServiceProviderInAppTest
 {
@@ -36,18 +37,22 @@ function restoreAppConfigFile(): void
 uses(ConfigureCopyAndRegisterServiceProviderInAppTest::class);
 
 it('can copy and register the service provider in the app', function () {
-    if (intval(app()->version()) >= 11) {
-        $this->markTestSkipped('Respects Laravel 11 skeleton patterns');
-    }
-
     $this
         ->artisan('package-tools:install')
         ->assertSuccessful();
 
-    assertStringContainsString(
-        "App\Providers\MyPackageServiceProvider::class",
-        file_get_contents(base_path('config/app.php'))
-    );
+    if (intval(app()->version()) >= 11) {
+        // This does not happen in L11 because of the different framework skeleton
+        assertStringNotContainsString(
+            "App\Providers\MyPackageServiceProvider::class",
+            file_get_contents(base_path('config/app.php'))
+        );
+    } else {
+        assertStringContainsString(
+            "App\Providers\MyPackageServiceProvider::class",
+            file_get_contents(base_path('config/app.php'))
+        );
+    }
 
     restoreAppConfigFile();
 });

--- a/tests/PackageServiceProviderTests/InstallCommandTests/CopyAndRegisterServiceProviderInAppTest.php
+++ b/tests/PackageServiceProviderTests/InstallCommandTests/CopyAndRegisterServiceProviderInAppTest.php
@@ -36,6 +36,10 @@ function restoreAppConfigFile(): void
 uses(ConfigureCopyAndRegisterServiceProviderInAppTest::class);
 
 it('can copy and register the service provider in the app', function () {
+    if (intval(app()->version()) >= 11) {
+        $this->markTestSkipped('Respects Laravel 11 skeleton patterns');
+    }
+
     $this
         ->artisan('package-tools:install')
         ->assertSuccessful();

--- a/tests/PackageServiceProviderTests/InstallCommandTests/CopyAndRegisterServiceProviderInAppTest.php
+++ b/tests/PackageServiceProviderTests/InstallCommandTests/CopyAndRegisterServiceProviderInAppTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use function PHPUnit\Framework\assertStringContainsString;
+use function PHPUnit\Framework\assertStringNotContainsString;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
-use function PHPUnit\Framework\assertStringNotContainsString;
 
 trait ConfigureCopyAndRegisterServiceProviderInAppTest
 {


### PR DESCRIPTION
Adding support for Laravel 11 development and testing, allowing for new features such as [registering optimization commands](https://github.com/spatie/laravel-package-tools/pull/147)