### PR TITLE
Allow command optimization

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -41,6 +41,8 @@ class Package
 
     public ?string $publishableProviderName = null;
 
+    public array $optimizeCommands = [];
+
     public function name(string $name): static
     {
         $this->name = $name;
@@ -214,6 +216,25 @@ class Package
     public function hasRoutes(...$routeFileNames): static
     {
         $this->routeFileNames = array_merge($this->routeFileNames, collect($routeFileNames)->flatten()->toArray());
+
+        return $this;
+    }
+
+    public function hasOptimization(?string $optimize = null, ?string $clear = null, ?string $key = null): static
+    {
+        $this->optimizeCommands[] = [
+            'optimize' => $optimize,
+            'clear' => $clear,
+            'key' => $key
+        ];
+
+        if (! in_array($optimize, $this->consoleCommands)) {
+            $this->consoleCommands[] = $optimize;
+        }
+
+        if (! in_array($clear, $this->consoleCommands)) {
+            $this->consoleCommands[] = $clear;
+        }
 
         return $this;
     }

--- a/src/Package.php
+++ b/src/Package.php
@@ -225,7 +225,7 @@ class Package
         $this->optimizeCommands[] = [
             'optimize' => $optimize,
             'clear' => $clear,
-            'key' => $key
+            'key' => $key,
         ];
 
         if (! in_array($optimize, $this->consoleCommands)) {

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -108,7 +108,7 @@ abstract class PackageServiceProvider extends ServiceProvider
             }
 
             if (! empty($this->package->optimizeCommands) && method_exists($this, 'optimizes')) {
-                foreach($this->package->optimizeCommands as $optimizeCmd) {
+                foreach ($this->package->optimizeCommands as $optimizeCmd) {
                     $this->optimizes($optimizeCmd['optimize'], $optimizeCmd['clear'], $optimizeCmd['key'] ?? null);
                 }
             }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -106,6 +106,12 @@ abstract class PackageServiceProvider extends ServiceProvider
                     $this->package->basePath('/../resources/dist') => public_path("vendor/{$this->package->shortName()}"),
                 ], "{$this->package->shortName()}-assets");
             }
+
+            if (! empty($this->package->optimizeCommands) && method_exists($this, 'optimizes')) {
+                foreach($this->package->optimizeCommands as $optimizeCmd) {
+                    $this->optimizes($optimizeCmd['optimize'], $optimizeCmd['clear'], $optimizeCmd['key'] ?? null);
+                }
+            }
         }
 
         if (! empty($this->package->commands)) {

--- a/tests/PackageServiceProviderTests/PackageOptimizationTest.php
+++ b/tests/PackageServiceProviderTests/PackageOptimizationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\Tests\TestClasses\FourthTestCommand;
+use Spatie\LaravelPackageTools\Tests\TestClasses\OtherTestCommand;
+use Spatie\LaravelPackageTools\Tests\TestClasses\TestCommand;
+use Spatie\LaravelPackageTools\Tests\TestClasses\ThirdTestCommand;
+
+trait ConfigurePackageOptimizationTest
+{
+    public function configurePackage(Package $package)
+    {
+        $package->name('laravel-package-tools');
+
+        if (version_compare(app()->version(), '11.27.1', '>=')) {
+            $package->hasOptimization(TestCommand::class, OtherTestCommand::class, 'laravel-package-tools');
+        }
+    }
+}
+
+uses(ConfigurePackageOptimizationTest::class);
+
+it('can call optimize commands', function () {
+    if (version_compare(app()->version(), '11.27.1', '<')) {
+        $this->markTestSkipped('Laravel 11+ functionality');
+    }
+
+    $this
+        ->artisan('test-command')
+        ->assertExitCode(0);
+});
+
+it('can call optimize:clear commands', function () {
+    if (version_compare(app()->version(), '11.27.1', '<')) {
+        $this->markTestSkipped('Laravel 11+ functionality');
+    }
+
+    $this
+        ->artisan('other-test-command')
+        ->assertExitCode(0);
+});
+
+it('registered optimize with laravel', function() {
+    if (version_compare(app()->version(), '11.27.1', '<')) {
+        $this->markTestSkipped('Laravel 11+ functionality');
+    }
+
+    $this->artisan('optimize')->expectsOutputToContain('laravel-package-tools');
+});
+
+it('registered optimize:clear with laravel', function() {
+    if (version_compare(app()->version(), '11.27.1', '<')) {
+        $this->markTestSkipped('Laravel 11+ functionality');
+    }
+
+   $this->artisan('optimize:clear')->expectsOutputToContain('laravel-package-tools');
+});

--- a/tests/PackageServiceProviderTests/PackageOptimizationTest.php
+++ b/tests/PackageServiceProviderTests/PackageOptimizationTest.php
@@ -1,10 +1,8 @@
 <?php
 
 use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\Tests\TestClasses\FourthTestCommand;
 use Spatie\LaravelPackageTools\Tests\TestClasses\OtherTestCommand;
 use Spatie\LaravelPackageTools\Tests\TestClasses\TestCommand;
-use Spatie\LaravelPackageTools\Tests\TestClasses\ThirdTestCommand;
 
 trait ConfigurePackageOptimizationTest
 {
@@ -40,7 +38,7 @@ it('can call optimize:clear commands', function () {
         ->assertExitCode(0);
 });
 
-it('registered optimize with laravel', function() {
+it('registered optimize with laravel', function () {
     if (version_compare(app()->version(), '11.27.1', '<')) {
         $this->markTestSkipped('Laravel 11+ functionality');
     }
@@ -48,10 +46,10 @@ it('registered optimize with laravel', function() {
     $this->artisan('optimize')->expectsOutputToContain('laravel-package-tools');
 });
 
-it('registered optimize:clear with laravel', function() {
+it('registered optimize:clear with laravel', function () {
     if (version_compare(app()->version(), '11.27.1', '<')) {
         $this->markTestSkipped('Laravel 11+ functionality');
     }
 
-   $this->artisan('optimize:clear')->expectsOutputToContain('laravel-package-tools');
+    $this->artisan('optimize:clear')->expectsOutputToContain('laravel-package-tools');
 });


### PR DESCRIPTION
Laravel [added support](https://github.com/laravel/framework/pull/52928) for integrating with the base `optimize` and `optimize:clear` commands, so this PR adds support for that functionality like so:
```php
$package->optimizes(Command::class, ClearCommand::class);
```

Note that this PR depends on [L11 development support](https://github.com/spatie/laravel-package-tools/pull/146) for testing, so those changes are also shown