### PR TITLE
Only prepends datetime if not already set.

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -167,7 +167,12 @@ abstract class PackageServiceProvider extends ServiceProvider
             }
         }
 
-        return database_path($migrationsPath . $now->format('Y_m_d_His') . '_' . Str::of($migrationFileName)->snake()->finish('.php'));
+        $filename = Str::of($migrationFileName)->snake()->finish('.php');
+        if (!self::startsWithDatetime($filename)) {
+            $filename = $now->format('Y_m_d_His') . '_' . $filename;
+        }
+
+        return database_path($migrationsPath . $filename);
     }
 
     public function registeringPackage()
@@ -247,5 +252,10 @@ abstract class PackageServiceProvider extends ServiceProvider
                 $this->loadMigrationsFrom($filePath);
             }
         }
+    }
+
+    private static function startsWithDatetime(string $string): bool {
+        $pattern = '/^\d{4}_\d{2}_\d{2}_\d{6}_/'; // Y_M_D_HIS_
+        return preg_match($pattern, $string) === 1;
     }
 }


### PR DESCRIPTION
This should fix the issue where a migration can be prefixed with a datetime twice (mentioned here https://github.com/spatie/laravel-package-tools/issues/143).

Adds a method called *startsWithDatetime* that can be extended if needed. 

In the filament-attachmate package I copied the migration file and removed the datetime in the name for testing.

![Screenshot from 2025-01-16 08-10-32](https://github.com/user-attachments/assets/5b229bc8-301b-4da1-a43b-1019e428bfeb)

When running

> php artisan vendor:publish --tag=filament-attachmate-migrations

I get the following as expected. 

![Screenshot from 2025-01-16 08-14-18](https://github.com/user-attachments/assets/4ace3036-3dfe-4012-85c8-d1b273e1cb97)

![Screenshot from 2025-01-16 08-14-50](https://github.com/user-attachments/assets/0657e1ed-44df-4821-b63e-3671fec3304e)
