### PR TITLE
Fix: Migration Name Prefixed with by timestamp twice

### DIFF
--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -12,8 +12,6 @@ use Spatie\LaravelPackageTools\Exceptions\InvalidPackage;
 
 abstract class PackageServiceProvider extends ServiceProvider
 {
-    const TIMESTAMP_PATTERN = '/^\d{4}_\d{2}_\d{2}_\d{6}_/';
-
     protected Package $package;
 
     abstract public function configurePackage(Package $package): void;
@@ -384,6 +382,6 @@ abstract class PackageServiceProvider extends ServiceProvider
 
     private static function stripTimestampPrefix(string $filename): string
     {
-        return preg_replace(self::TIMESTAMP_PATTERN, '', $filename);
+        return preg_replace('/^\d{4}_\d{2}_\d{2}_\d{6}_/', '', $filename);
     }
 }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -12,6 +12,8 @@ use Spatie\LaravelPackageTools\Exceptions\InvalidPackage;
 
 abstract class PackageServiceProvider extends ServiceProvider
 {
+    const TIMESTAMP_PATTERN = '/^\d{4}_\d{2}_\d{2}_\d{6}_/';
+
     protected Package $package;
 
     abstract public function configurePackage(Package $package): void;
@@ -373,9 +375,15 @@ abstract class PackageServiceProvider extends ServiceProvider
             }
         }
 
+        $migrationFileName = self::stripTimestampPrefix($migrationFileName);
         $timestamp = $now->format('Y_m_d_His');
-        $migrationFileName = Str::of($migrationFileName)->snake()->finish('.php');
+        $formattedFileName = Str::of($migrationFileName)->snake()->finish('.php');
 
-        return database_path($migrationsPath . $timestamp . '_' . $migrationFileName);
+        return database_path("{$migrationsPath}{$timestamp}_{$formattedFileName}");
+    }
+
+    private static function stripTimestampPrefix(string $filename): string
+    {
+        return preg_replace(self::TIMESTAMP_PATTERN, '', $filename);
     }
 }

--- a/tests/PackageServiceProviderTests/PackageDiscoversMigrationsTest.php
+++ b/tests/PackageServiceProviderTests/PackageDiscoversMigrationsTest.php
@@ -60,6 +60,6 @@ it('can run migrations which registers them', function () {
     /** @var \Illuminate\Database\Migrations\Migrator $migrator */
     $migrator = app('migrator');
 
-    $this->assertCount(5, $migrator->paths());
+    $this->assertCount(6, $migrator->paths());
     $this->assertStringContainsString('laravel_package_tools', $migrator->paths()[0]);
 });

--- a/tests/PackageServiceProviderTests/PackageDiscoversMigrationsTest.php
+++ b/tests/PackageServiceProviderTests/PackageDiscoversMigrationsTest.php
@@ -61,5 +61,5 @@ it('can run migrations which registers them', function () {
     $migrator = app('migrator');
 
     $this->assertCount(6, $migrator->paths());
-    $this->assertStringContainsString('laravel_package_tools', $migrator->paths()[0]);
+    $this->assertStringContainsString('laravel_package_tools', $migrator->paths()[1]);
 });

--- a/tests/PackageServiceProviderTests/PackageMigrationTest.php
+++ b/tests/PackageServiceProviderTests/PackageMigrationTest.php
@@ -13,6 +13,7 @@ trait ConfigurePackageMigrationTest
             ->name('laravel-package-tools')
             ->hasMigration('create_another_laravel_package_tools_table')
             ->hasMigration('create_regular_laravel_package_tools_table')
+            ->hasMigration('2025_03_14_011123_create_custom_table')
             ->runsMigrations();
     }
 }
@@ -26,6 +27,15 @@ it('can publish the migration', function () {
         ->assertExitCode(0);
 
     assertMigrationPublished('create_another_laravel_package_tools_table.php');
+});
+
+it('can publish migration with a prefixed timestamp', function () {
+    $this
+        ->artisan('vendor:publish --tag=package-tools-migrations')
+        ->doesntExpectOutput('hey')
+        ->assertExitCode(0);
+
+    assertMigrationPublished('2020_01_01_000003_create_custom_table.php');
 });
 
 it('can publish the migration without being stubbed', function () {
@@ -80,6 +90,6 @@ it('can run migrations which registers them', function () {
     /** @var \Illuminate\Database\Migrations\Migrator $migrator */
     $migrator = app('migrator');
 
-    $this->assertCount(2, $migrator->paths());
+    $this->assertCount(3, $migrator->paths());
     $this->assertStringContainsString('laravel_package_tools', $migrator->paths()[0]);
 });

--- a/tests/TestPackage/database/migrations/2025_03_14_011123_create_custom_table.php.stub
+++ b/tests/TestPackage/database/migrations/2025_03_14_011123_create_custom_table.php.stub
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCustomTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('custom', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
Description
This PR addresses [this issue](https://github.com/spatie/laravel-package-tools/issues/143) where migration files were being prefixed with timestamps twice during the publishing process. The fix ensures that migration filenames are correctly formatted by stripping any redundant timestamp prefixes.

Related Issue
[#143](https://github.com/spatie/laravel-package-tools/issues/143)