### PR TITLE
Normalize view paths to prevent cache duplication

### DIFF
--- a/src/Concerns/PackageServiceProvider/ProcessViews.php
+++ b/src/Concerns/PackageServiceProvider/ProcessViews.php
@@ -11,7 +11,8 @@ trait ProcessViews
         }
 
         $namespace = $this->package->viewNamespace;
-        $vendorViews = $this->package->basePath('/../resources/views');
+        $viewPath = $this->package->basePath('/../resources/views');
+        $vendorViews = realpath($viewPath) ?: $viewPath;
         $appViews = base_path("resources/views/vendor/{$this->packageView($namespace)}");
 
         $this->loadViewsFrom($vendorViews, $this->package->viewNamespace());

--- a/src/Concerns/PackageServiceProvider/ProcessViews.php
+++ b/src/Concerns/PackageServiceProvider/ProcessViews.php
@@ -11,8 +11,8 @@ trait ProcessViews
         }
 
         $namespace = $this->package->viewNamespace;
-        $viewPath = $this->package->basePath('/../resources/views');
-        $vendorViews = realpath($viewPath) ?: $viewPath;
+        $viewsPath = $this->package->basePath('/../resources/views');
+        $vendorViews = realpath($viewsPath) ?: $viewsPath;
         $appViews = base_path("resources/views/vendor/{$this->packageView($namespace)}");
 
         $this->loadViewsFrom($vendorViews, $this->package->viewNamespace());


### PR DESCRIPTION
This PR fixes a view cache duplication issue that causes [performance overhead in normal environments](https://github.com/spatie/laravel-package-tools/discussions/170) and more seriously, [race conditions in multi-instance deployments](https://github.com/filamentphp/filament/issues/16231).

When packages register views using paths like `src/../resources/views`, Laravel generates different cache files than when using `php artisan view:cache` (which normalizes the paths). This affects all applications using packages built with `laravel-package-tools`.

Here's an example from my local testing. Two files, same contents, different last line (i.e. the view is cached twice):

File 1:
```PHP
.....
            <?php endif; ?>
        </div>
    <?php endif; ?>
</<?php echo e($tag); ?>>
<?php /**PATH /vendor/filament/support/resources/views/components/button/index.blade.php ENDPATH**/ ?>
```

File 2:
```PHP
.....
            <?php endif; ?>
        </div>
    <?php endif; ?>
</<?php echo e($tag); ?>>
<?php /**PATH /vendor/filament/support/src/../resources/views/components/button/index.blade.php ENDPATH**/ ?>
```

By normalizing view paths using `realpath()` before registering them, all paths are canonical and match the `view:cache` command.