### PR TITLE
Fix: Accept both Carbon and CarbonImmutable types

### DIFF
--- a/src/Concerns/PackageServiceProvider/ProcessMigrations.php
+++ b/src/Concerns/PackageServiceProvider/ProcessMigrations.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelPackageTools\Concerns\PackageServiceProvider;
 
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
@@ -74,7 +75,7 @@ trait ProcessMigrations
         }
     }
 
-    protected function generateMigrationName(string $migrationFileName, Carbon $now): string
+    protected function generateMigrationName(string $migrationFileName, Carbon|CarbonImmutable $now): string
     {
         $migrationsPath = 'migrations/' . dirname($migrationFileName) . '/';
         $migrationFileName = basename($migrationFileName);


### PR DESCRIPTION
**Problem**
generateMigrationName method in ProcessMigrations trait expects Carbon instance as the second argument which throws TypeError when passing CarbonImmutable instance by defining Date::use(CarbonImmutable::class) globally.

**Solution**
Accept both Carbon and CarbonImmutable instances.