### PR TITLE
Performance: ProcessMigrations - only generate migration name when needed

### DIFF
--- a/src/Concerns/PackageServiceProvider/ProcessMigrations.php
+++ b/src/Concerns/PackageServiceProvider/ProcessMigrations.php
@@ -21,7 +21,6 @@ trait ProcessMigrations
 
         foreach ($this->package->migrationFileNames as $migrationFileName) {
             $vendorMigration = $this->package->basePath("/../database/migrations/{$migrationFileName}.php");
-            $appMigration = $this->generateMigrationName($migrationFileName, $now->addSecond());
 
             // Support for the .stub file extension
             if (! file_exists($vendorMigration)) {
@@ -29,6 +28,8 @@ trait ProcessMigrations
             }
 
             if ($this->app->runningInConsole()) {
+                $appMigration = $this->generateMigrationName($migrationFileName, $now->addSecond());
+
                 $this->publishes(
                     [$vendorMigration => $appMigration],
                     "{$this->package->shortName()}-migrations"


### PR DESCRIPTION
As the `$appMigration` var is only used in console mode for publishing migrations, we should only set it when needed.

While this method has a very small overhead, when you have several packages using this function, it does add up.

ie: on my project, this small change saves me 10-15ms boot time 