### PR TITLE
fix: strip timestamp prefix before checking for existing migrations

### DIFF
--- a/src/Concerns/PackageServiceProvider/ProcessMigrations.php
+++ b/src/Concerns/PackageServiceProvider/ProcessMigrations.php
@@ -81,6 +81,8 @@ trait ProcessMigrations
         $migrationsPath = 'migrations/' . dirname($migrationFileName) . '/';
         $migrationFileName = basename($migrationFileName);
 
+        $migrationFileName = self::stripTimestampPrefix($migrationFileName);
+
         $len = strlen($migrationFileName) + 4;
 
         if (Str::contains($migrationFileName, '/')) {
@@ -94,7 +96,6 @@ trait ProcessMigrations
             }
         }
 
-        $migrationFileName = self::stripTimestampPrefix($migrationFileName);
         $timestamp = $now->format('Y_m_d_His');
         $formattedFileName = Str::of($migrationFileName)->snake()->finish('.php');
 


### PR DESCRIPTION
The generateMigrationName method now strips the timestamp prefix from migration filenames BEFORE checking for existing migrations in the database/migrations folder. This fixes the bug where migration files with pre-existing timestamps were getting double-prefixed when published.

Fixes #143